### PR TITLE
Rearranging the container image build steps to reduce image size

### DIFF
--- a/apps/interactor/docker/harpoon.yml
+++ b/apps/interactor/docker/harpoon.yml
@@ -13,18 +13,19 @@ images:
     commands:
       - FROM python:3.8.1-slim
 
-      - - RUN
-        - apt-get update
-          && apt-get install gcc -y
-          && rm -rf /var/lib/apt/lists/*
-
       - ADD apps/interactor/command /project/
       - ADD apps/interactor /project/interactor
       - ADD modules /project/modules
 
       - WORKDIR /project/config
 
-      - RUN pip install pip -U && pip install /project/modules /project/interactor
+      - - RUN
+        - apt-get update
+          && apt-get install gcc -y
+          && pip install pip -U && pip install /project/modules /project/interactor
+          && apt-get purge -y gcc
+          && apt-get autoremove -y
+          && rm -rf /var/lib/apt/lists/*
 
       - ENV INTERACTOR_HOST 0.0.0.0
       - CMD lifx lan:interactor


### PR DESCRIPTION
This change should also remove the need to squash the final image as I've merged the two `RUN` directives into one.

Signed-off-by: Avi Miller <me@dje.li>