### PR TITLE
[interactor] Enable Docker container health status

### DIFF
--- a/apps/interactor/command
+++ b/apps/interactor/command
@@ -6,7 +6,7 @@ if [[ -z $1 ]]; then
 fi
 
 ARGS=$(printf '{"command": "%s"}' "$1")
-if [[ ! -z $2 ]]; then
+if [[ -n $2 ]]; then
   ARGS=$(printf '{"command": "%s", "args": %s}' "$1" "$2")
 fi
 

--- a/apps/interactor/docker/harpoon.yml
+++ b/apps/interactor/docker/harpoon.yml
@@ -13,19 +13,20 @@ images:
     commands:
       - FROM python:3.8.1-slim
 
-      - ADD apps/interactor/command /project/
       - ADD apps/interactor /project/interactor
       - ADD modules /project/modules
 
       - WORKDIR /project/config
 
       - - RUN
-        - apt-get update
-          && apt-get install gcc -y
+        - ln -s /project/interactor/command /project/command
+          && apt-get update
+          && apt-get install curl gcc -y
           && pip install pip -U && pip install /project/modules /project/interactor
           && apt-get purge -y gcc
           && apt-get autoremove -y
           && rm -rf /var/lib/apt/lists/*
 
       - ENV INTERACTOR_HOST 0.0.0.0
-      - CMD lifx lan:interactor
+      - HEALTHCHECK CMD lifx interactor_healthcheck --silent || exit 1
+      - CMD ["lifx", "lan:interactor"]


### PR DESCRIPTION
Added a healthcheck task to Interactor that issues a status
command to Interactor and returns the status via exit code.

This commit also fixes and improves the included command script
by adding a task to return the configured bind address and by
adding curl to the image.

This resolves #23 
This resolves #29

Signed-off-by: Avi Miller <me@dje.li>