### PR TITLE
[docker] Change base image to python:3.8-slim

### DIFF
--- a/apps/interactor/docker/harpoon.yml
+++ b/apps/interactor/docker/harpoon.yml
@@ -11,7 +11,7 @@ images:
       parent_dir: "{config_root}/../../../"
 
     commands:
-      - FROM python:3.8.1-slim
+      - FROM python:3.8-slim
 
       - ADD apps/interactor /project/interactor
       - ADD modules /project/modules


### PR DESCRIPTION
The official Python images offer varying degrees of version specificity.
By changing to python:3.8-slim the build process will use the latest
available 3.8 version, which at this commit was 3.8.6, instead of
being locked to Python 3.8.1.

Signed-off-by: Avi Miller <me@dje.li>