### PR TITLE
[bug] Python 3.6 doesn't support await in fstrings

### DIFF
--- a/apps/interactor/interactor/addon.py
+++ b/apps/interactor/interactor/addon.py
@@ -89,8 +89,9 @@ async def interactor_healthcheck(collector, **kwargs):
         try:
             async with session.put(uri, json={"command": "status"}) as response:
                 if response.status != 200:
+                    content = (await response.content.read()).decode()
                     raise InteractorError(
-                        f"Healthcheck failed: {response.status}: {(await response.content.read()).decode()}"
+                        f"Healthcheck failed: {response.status}: {content}"
                     )
 
         except aiohttp.client_exceptions.ClientConnectorError as error:


### PR DESCRIPTION
The EL8-based distros like RHEL, CentOS and Oracle Linux default
to Python 3.6. This fix allows the Interactor RPM to build for those
platforms.

Fixes #39.

Signed-off-by: Avi Miller <me@dje.li>