### PR TITLE
[interactor] Rename the Interactor task back to [lan:]interactor

### DIFF
--- a/apps/interactor/interactor/addon.py
+++ b/apps/interactor/interactor/addon.py
@@ -20,7 +20,7 @@ def __lifx__(collector, *args, **kwargs):
 
 
 @task.register(task_group="Interactor")
-class interact(task.GracefulTask):
+class interactor(task.GracefulTask):
     """
     Start a daemon that will watch your network for LIFX lights and interact with them
     """


### PR DESCRIPTION
I'm not sure if the task name change was deliberate, but folks
may have existing scripts or systemd units that use the old task
name and breaking that is bad juju.

This also fixes the container image which is currently broken as
it also uses "lan:interactor" as the task name.

Fixes #49 

Signed-off-by: Avi Miller <me@dje.li>