### PR TITLE
[interactor] adding server long tasks (including circadian)

### DIFF
--- a/apps/interactor/interactor/addon.py
+++ b/apps/interactor/interactor/addon.py
@@ -38,12 +38,12 @@ class interactor(task.GracefulTask):
         await task.fill_task(self.collector, "migrate").run(extra="upgrade head")
 
         async def add_registered_tasks(meta, task_register):
-            for name, t in self.options.tasks.items():
+            meta = Meta(self.collector.configuration.wrapped(), []).at("tasks")
+            meta.everything.update({"natural_light_presets": self.options.tasks.natural_light})
+
+            for name, t in self.options.tasks.presets.items():
                 if not t.skip:
-                    meta = (
-                        Meta(self.collector.configuration, []).at("interactor").at("tasks").at(name)
-                    )
-                    await task_register.add(meta, name, t.type, t.options)
+                    await task_register.add(meta.at(name), name, t)
 
         async with self.target.session() as sender:
             await Server(

--- a/apps/interactor/interactor/addon.py
+++ b/apps/interactor/interactor/addon.py
@@ -37,13 +37,13 @@ class interactor(task.GracefulTask):
 
         await task.fill_task(self.collector, "migrate").run(extra="upgrade head")
 
-        def add_registered_tasks(meta, task_register):
+        async def add_registered_tasks(meta, task_register):
             for name, t in self.options.tasks.items():
                 if not t.skip:
                     meta = (
                         Meta(self.collector.configuration, []).at("interactor").at("tasks").at(name)
                     )
-                    task_register.add(meta, name, t.type, t.options)
+                    await task_register.add(meta, name, t.type, t.options)
 
         async with self.target.session() as sender:
             await Server(

--- a/apps/interactor/interactor/commander/commands/tasks.py
+++ b/apps/interactor/interactor/commander/commands/tasks.py
@@ -1,0 +1,78 @@
+from interactor.commander.store import store
+
+from delfick_project.norms import dictobj, sb, Meta
+
+
+@store.command(name="tasks/pause")
+class PauseTaskCommand(store.Command):
+    """
+    Pause a running task
+    """
+
+    task_register = store.injected("task_register")
+
+    name = dictobj.Field(sb.string_spec, wrapper=sb.required, help="The name of the task to pause")
+
+    async def execute(self):
+        self.task_register.pause(self.name)
+        return await self.task_register.status()
+
+
+@store.command(name="tasks/resume")
+class ResumeTaskCommand(store.Command):
+    """
+    Resume a running task
+    """
+
+    task_register = store.injected("task_register")
+
+    name = dictobj.Field(sb.string_spec, wrapper=sb.required, help="The name of the task to resume")
+
+    async def execute(self):
+        self.task_register.resume(self.name)
+        return await self.task_register.status()
+
+
+@store.command(name="tasks/remove")
+class RemoveTaskCommand(store.Command):
+    """
+    Remove a running task
+    """
+
+    task_register = store.injected("task_register")
+
+    name = dictobj.Field(sb.string_spec, wrapper=sb.required, help="The name of the task to remove")
+
+    async def execute(self):
+        self.task_register.remove(self.name)
+        return await self.task_register.status()
+
+
+@store.command(name="tasks/add")
+class AddTaskCommand(store.Command):
+    """
+    Add a new task
+    """
+
+    task_register = store.injected("task_register")
+
+    name = dictobj.Field(sb.string_spec, wrapper=sb.required, help="The name of the task")
+    type = dictobj.Field(sb.string_spec, wrapper=sb.required, help="The type of task")
+    options = dictobj.Field(sb.dictionary_spec, help="The options given to the task")
+
+    async def execute(self):
+        meta = Meta({}, []).at("request")
+        self.task_register.add(meta, self.name, self.type, self.options)
+        return await self.task_register.status()
+
+
+@store.command(name="tasks/status")
+class TaskStatusCommand(store.Command):
+    """
+    Show status of current running tasks
+    """
+
+    task_register = store.injected("task_register")
+
+    async def execute(self):
+        return await self.task_register.status()

--- a/apps/interactor/interactor/options.py
+++ b/apps/interactor/interactor/options.py
@@ -35,11 +35,6 @@ class Options(dictobj.Spec):
     )
 
     tasks = dictobj.Field(
-        sb.dictof(
-            sb.string_spec(),
-            TaskRegister.Config.FieldSpec(formatter=MergedOptionStringFormatter),
-        ),
-        help="""
-    A dictionary of {name: task} where each task is a dictionary of type and options
-    """,
+        TaskRegister.Config.FieldSpec(formatter=MergedOptionStringFormatter),
+        help="""Options for any preset tasks""",
     )

--- a/apps/interactor/interactor/options.py
+++ b/apps/interactor/interactor/options.py
@@ -1,3 +1,5 @@
+from interactor.tasks.register import TaskRegister
+
 from photons_app.formatter import MergedOptionStringFormatter
 
 from delfick_project.norms import dictobj, sb
@@ -30,4 +32,14 @@ class Options(dictobj.Spec):
             formatter=MergedOptionStringFormatter
         ),
         help="Database options",
+    )
+
+    tasks = dictobj.Field(
+        sb.dictof(
+            sb.string_spec(),
+            TaskRegister.Config.FieldSpec(formatter=MergedOptionStringFormatter),
+        ),
+        help="""
+    A dictionary of {name: task} where each task is a dictionary of type and options
+    """,
     )

--- a/apps/interactor/interactor/server.py
+++ b/apps/interactor/interactor/server.py
@@ -193,17 +193,17 @@ class Server(Server):
         self.task_register = TaskRegister(self.final_future, self.tasks, self.commander.meta)
         self.task_register._merged_options_formattable = True
 
-        self.cleaners.append(self.task_register.finish)
         await self.task_register.start()
 
         for register in registerers:
             register(self.task_register)
 
         if self.add_registered_tasks is not None:
-            self.add_registered_tasks(self.commander.meta, self.task_register)
+            await self.add_registered_tasks(self.commander.meta, self.task_register)
 
     async def cleanup(self):
         self.tasks.add(self.animations.stop())
         await hp.wait_for_all_futures(
             *self.wsconnections.values(), name="Server::cleanup[wait_for_wsconnections]"
         )
+        await self.task_register.finish()

--- a/apps/interactor/interactor/tasks/__init__.py
+++ b/apps/interactor/interactor/tasks/__init__.py
@@ -1,0 +1,11 @@
+import importlib
+import os
+
+
+for module in os.listdir(os.path.join(os.path.dirname(__file__), "registered")):
+    if module.startswith("_") or module.startswith("."):
+        continue
+    if module.endswith(".py"):
+        module = module[:-3]
+
+    importlib.import_module(f"interactor.tasks.registered.{module}")

--- a/apps/interactor/interactor/tasks/location.py
+++ b/apps/interactor/interactor/tasks/location.py
@@ -1,0 +1,120 @@
+from interactor.tasks.time_specs import time_spec
+
+from photons_app.formatter import MergedOptionStringFormatter
+from photons_app.errors import PhotonsAppError
+
+from delfick_project.norms import dictobj, sb
+from astral.geocoder import database, lookup
+from astral.location import Location
+from astral import LocationInfo
+
+
+class NoSuchLocation(PhotonsAppError):
+    desc = "Couldn't find this location"
+
+
+class NoSuchNaturalLightPreset(PhotonsAppError):
+    desc = "There is no configuration for natural light with this name"
+
+
+class NaturalLightPresets:
+    @classmethod
+    def spec(kls):
+        return sb.container_spec(
+            kls,
+            sb.dictof(
+                sb.string_spec(), NaturalLight.FieldSpec(formatter=MergedOptionStringFormatter)
+            ),
+        )
+
+    def __init__(self, presets):
+        self.presets = presets
+
+    def find(self, name):
+        if name not in self.presets:
+            raise NoSuchNaturalLightPreset(wanted=name, available=sorted(self.presets))
+
+        return self.presets[name]
+
+
+class location_spec(sb.Spec):
+    def normalise_filled(self, meta, val):
+        if isinstance(val, str):
+            try:
+                info = Location(lookup(val, database()))
+            except KeyError:
+                raise NoSuchLocation(want=val, meta=meta)
+        else:
+            options = sb.set_options(
+                name=sb.required(sb.string_spec()),
+                region=sb.required(sb.string_spec()),
+                timezone=sb.required(sb.string_spec()),
+                latitude=sb.required(sb.float_spec()),
+                longitude=sb.required(sb.float_spec()),
+            ).normalise(meta, val)
+
+            info = LocationInfo(
+                options["name"],
+                options["region"],
+                options["timezone"],
+                options["latitude"],
+                options["longitude"],
+            )
+
+        return Location(info)
+
+
+class NaturalLight(dictobj.Spec):
+    location = dictobj.Field(
+        location_spec,
+        wrapper=sb.required,
+        help="""
+    Either the name of your city, i.e. "Melbourne" or a dictionary of {name, region, timezone, latitude, longitude}
+
+    For example:
+
+    .. code-block:: yaml
+
+        location:
+            name: "Melbourne"
+            region: "Australia"
+            timezone: "Australia/Melbourne"
+            latitude: -37.8
+            longitude: 144.95
+
+    If you specify a name we'll use https://astral.readthedocs.io/en/latest/#geocoder
+    """,
+    )
+
+    sunset_at = dictobj.NullableField(
+        time_spec(default=""),
+        help="""
+    You may set a static sunset time as "HH:MM" or leave this option out for it to
+    be determined dynamically
+    """,
+    )
+    sunrise_at = dictobj.NullableField(
+        time_spec(default=""),
+        help="""
+    You may set a static sunset time as "HH:MM" or leave this option out for it to
+    be determined dynamically
+    """,
+    )
+
+    def sunrise(self, date):
+        if self.sunrise_at is not None:
+            return date.replace(hour=self.sunrise_at[0], minute=self.sunrise_at[1])
+        else:
+            return self.location.sunrise(date)
+
+    def sunset(self, date):
+        if self.sunset_at is not None:
+            return date.replace(hour=self.sunset_at[0], minute=self.sunset_at[1])
+        else:
+            return self.location.sunset(date)
+
+    def solar_noon(self, date):
+        return self.location.noon(date)
+
+    def solar_midnight(self, date):
+        return self.location.midnight(date)

--- a/apps/interactor/interactor/tasks/register.py
+++ b/apps/interactor/interactor/tasks/register.py
@@ -1,0 +1,156 @@
+from interactor.commander.command import DeviceChangeMixin
+
+from photons_app.formatter import MergedOptionStringFormatter
+from photons_app.errors import PhotonsAppError
+from photons_app import helpers as hp
+
+from photons_control.script import FromGenerator, Repeater
+
+from delfick_project.option_merge import MergedOptions
+from delfick_project.norms import dictobj, sb, Meta
+import asyncio
+import logging
+
+
+log = logging.getLogger("interactor.tasks.register")
+
+registerers = []
+
+
+def registerer(func):
+    registerers.append(func)
+    return func
+
+
+class pauser_spec(sb.Spec):
+    def normalise(self, meta, val):
+        event = asyncio.Event()
+        if val is True:
+            event.set()
+        return event
+
+
+class NoSuchType(PhotonsAppError):
+    desc = "No such task type"
+
+
+class AlreadyCreatedTask(PhotonsAppError):
+    desc = "Already created a task with this name"
+
+
+class DeviceTask(DeviceChangeMixin):
+    paused = dictobj.Field(
+        pauser_spec,
+        help="""
+    Set to True if you want this task to be paused on start
+    """,
+    )
+
+    update_every = dictobj.Field(
+        sb.float_spec,
+        default=10,
+        help="""
+    Update the lights every this seconds. Defaults to 10 seconds
+    """,
+    )
+
+    async def run(self, final_future, action):
+        async def gen(reference, sender, **kwargs):
+            if final_future.done():
+                raise Repeater.Stop()
+
+            if self.paused.is_set():
+                return
+
+            async for msg in action(reference, sender, **kwargs):
+                yield msg
+
+        await self.send(
+            Repeater(
+                FromGenerator(gen, reference_override=self.device_finder),
+                min_loop_time=self.update_every,
+            ),
+            self.device_finder,
+        )
+
+    async def status(self, name):
+        return {
+            "name": name,
+            "paused": self.paused.is_set(),
+            "serials": await self.serials,
+        }
+
+
+class TaskRegister(hp.AsyncCMMixin):
+    def __init__(self, final_future, task_holder, meta):
+        self.meta = meta
+        self.task_holder = task_holder
+        self.final_future = final_future
+
+        self.types = {}
+        self.registered = {}
+
+    class Config(dictobj.Spec):
+        type = dictobj.Field(sb.string_spec, wrapper=sb.required)
+        skip = dictobj.Field(sb.boolean, default=False)
+        options = dictobj.Field(sb.dictionary_spec)
+
+    def register(self, typ, options_kls, run):
+        self.types[typ] = (options_kls, run)
+
+    async def status(self):
+        status = {}
+        for name, (_, _, options) in sorted(self.registered.items()):
+            if hasattr(options, "status"):
+                status[name] = await options.status(name)
+            else:
+                status[name] = {"name": name}
+
+        return status
+
+    async def start(self):
+        return self
+
+    async def finish(self, exc_typ=None, exc=None, tb=None):
+        for name in list(self.registered):
+            self.remove(name)
+
+    def add(self, meta, name, typ, options):
+        if name in self.registered:
+            raise AlreadyCreatedTask(task=name, running=sorted(self.registered))
+
+        if typ not in self.types:
+            raise NoSuchType(task=name, wanted=typ, available=sorted(self.types))
+
+        meta = Meta(MergedOptions.using(meta.everything, self.meta.everything), meta.path)
+
+        options_kls, run = self.types[typ]
+        options = options_kls.FieldSpec(formatter=MergedOptionStringFormatter).normalise(
+            meta, options
+        )
+
+        final_future = hp.ChildOfFuture(
+            self.final_future, name=f"TaskRegistered::create[{name}.final_future]"
+        )
+        log.info(hp.lc("Starting task", name=name, type=typ))
+        task = self.task_holder.add(run(final_future, options))
+        self.registered[name] = (task, final_future, options)
+
+    def remove(self, name):
+        if name in self.registered:
+            task, final_future, _ = self.registered[name]
+            final_future.cancel()
+            task.cancel()
+            del self.registered[name]
+
+    def pause(self, name):
+        if name in self.registered:
+            options = self.registered[name][2]
+            if hasattr(options, "paused"):
+                options.paused.set()
+
+    def resume(self, name):
+        if name in self.registered:
+            options = self.registered[name][2]
+            if hasattr(options, "paused"):
+                options.paused.clear()

--- a/apps/interactor/interactor/tasks/registered/circadian/__init__.py
+++ b/apps/interactor/interactor/tasks/registered/circadian/__init__.py
@@ -1,0 +1,52 @@
+from interactor.tasks.registered.circadian.options import Options
+from interactor.tasks.register import registerer
+
+from photons_control.script import FromGenerator
+from photons_messages import LightMessages
+
+from datetime import datetime
+
+
+@registerer
+def register(tasks):
+    tasks.register("circadian", Options, run)
+
+
+async def run(final_future, options):
+    async def action(reference, sender, **kwargs):
+        now = datetime.now()
+        if int(now.strftime("%w")) not in options.days:
+            return
+
+        serials = []
+        async for pkt in sender(LightMessages.GetColor(), reference, **kwargs):
+            if pkt | LightMessages.LightState:
+                if pkt.saturation < options.break_saturation_threshold:
+                    serials.append(pkt.serial)
+
+        if not serials:
+            return
+
+        bright, kelv = options.circadian.change_for(
+            now,
+            min_kelvin=options.min_kelvin,
+            max_kelvin=options.max_kelvin,
+            min_brightness=options.min_brightness,
+            max_brightness=options.max_brightness,
+        )
+
+        async def apply_change(reference, sender, **kwargs):
+            level = 0
+            if now in options.lights_on_range:
+                level = 65535
+
+            if options.paused.is_set():
+                return
+
+            if options.change_power:
+                yield LightMessages.SetLightPower(level=level, duration=1)
+            yield LightMessages.SetWaveformOptional(brightness=bright, kelvin=kelv)
+
+        yield FromGenerator(apply_change, reference_override=serials)
+
+    await options.run(final_future, action)

--- a/apps/interactor/interactor/tasks/registered/circadian/circadian.py
+++ b/apps/interactor/interactor/tasks/registered/circadian/circadian.py
@@ -87,4 +87,9 @@ class Circadian:
         else:
             kelvin = min_kelvin
 
+        if kelvin > max_kelvin:
+            kelvin = max_kelvin
+        elif kelvin < min_kelvin:
+            kelvin = min_kelvin
+
         return brightness, int(kelvin)

--- a/apps/interactor/interactor/tasks/registered/circadian/circadian.py
+++ b/apps/interactor/interactor/tasks/registered/circadian/circadian.py
@@ -1,0 +1,90 @@
+from datetime import timedelta
+
+
+class Circadian:
+    def __init__(self, location, *, sunrise_at, sunset_at):
+        self.location = location
+        self.sunset_at = sunset_at
+        self.sunrise_at = sunrise_at
+
+    def sunrise(self, date):
+        if self.sunrise_at is not None:
+            return date.replace(hour=self.sunrise_at[0], minute=self.sunrise_at[1])
+        else:
+            return self.location.sunrise(date)
+
+    def sunset(self, date):
+        if self.sunset_at is not None:
+            return date.replace(hour=self.sunset_at[0], minute=self.sunset_at[1])
+        else:
+            return self.location.sunset(date)
+
+    def change_for(self, now, *, min_kelvin, max_kelvin, min_brightness, max_brightness):
+        """
+        Return (brightness, kelvin) to apply.
+
+        Heavily based on
+        https://github.com/claytonjn/hass-circadian_lighting/blob/ff4854e7b72db62252b10a773163588299e06cdc/custom_components/circadian_lighting/__init__.py
+        """
+        yesterday = now - timedelta(days=1)
+        tomorrow = now + timedelta(days=1)
+
+        sunrise = self.sunrise(now).timestamp()
+        sunset = self.sunset(now).timestamp()
+        solar_noon = self.location.noon(now).timestamp()
+        solar_midnight = self.location.midnight(now).timestamp()
+
+        now = now.timestamp()
+
+        # after midnight, but before sunrise
+        if now < sunrise:
+            # Because it's before sunrise (and after midnight) sunset must have happend yesterday
+            yesterday_sunset = self.sunset(yesterday).timestamp()
+            yesterday_solar_midnight = self.location.midnight(yesterday).timestamp()
+            if solar_midnight > sunset and yesterday_solar_midnight > yesterday_sunset:
+                # Solar midnight is after sunset so use yesterdays time
+                solar_midnight = yesterday_solar_midnight
+
+        # after sunset, but before midnight
+        elif now > sunset:
+            # Because it's after sunset (and before midnight) sunrise should happen tomorrow
+            tomorrow_solar_midnight = self.location.midnight(tomorrow).timestamp()
+            tomorrow_sunrise = self.sunrise(tomorrow).timestamp()
+
+            if solar_midnight < sunrise and tomorrow_solar_midnight < tomorrow_sunrise:
+                # Solar midnight is before sunrise so use tomorrow's time
+                solar_midnight = tomorrow_solar_midnight
+
+        if now > sunrise and now < sunset:
+            h = solar_noon
+            k = 100
+            if now < solar_noon:
+                x = sunrise
+            else:
+                x = sunset
+            y = 0
+
+        else:
+            h = solar_midnight
+            k = -100
+            if now < solar_midnight:
+                x = sunset
+            else:
+                x = sunrise
+            y = 0
+
+        a = (y - k) / (h - x) ** 2
+        percent = a * (now - h) ** 2 + k
+
+        brightness = percent / 100
+        if brightness < min_brightness:
+            brightness = min_brightness
+        elif brightness > max_brightness:
+            brightness = max_brightness
+
+        if percent > 0:
+            kelvin = ((max_kelvin - min_kelvin) * (percent / 100)) + min_kelvin
+        else:
+            kelvin = min_kelvin
+
+        return brightness, int(kelvin)

--- a/apps/interactor/interactor/tasks/registered/circadian/options.py
+++ b/apps/interactor/interactor/tasks/registered/circadian/options.py
@@ -1,0 +1,160 @@
+from interactor.tasks.registered.circadian.circadian import Circadian
+from interactor.tasks.time_specs import time_spec, time_range_spec
+from interactor.tasks.registered.circadian.specs import days_spec
+from interactor.tasks.register import DeviceTask
+
+from photons_app.errors import PhotonsAppError
+from photons_app import helpers as hp
+
+from delfick_project.norms import dictobj, sb
+from astral.geocoder import database, lookup
+from astral.location import Location
+from astral import LocationInfo
+from datetime import datetime
+
+
+class NoSuchLocation(PhotonsAppError):
+    desc = "Couldn't find this location"
+
+
+class location_spec(sb.Spec):
+    def normalise_filled(self, meta, val):
+        if isinstance(val, str):
+            try:
+                info = Location(lookup(val, database()))
+            except KeyError:
+                raise NoSuchLocation(want=val, meta=meta)
+        else:
+            options = sb.set_options(
+                name=sb.required(sb.string_spec()),
+                region=sb.required(sb.string_spec()),
+                timezone=sb.required(sb.string_spec()),
+                latitude=sb.required(sb.integer_spec()),
+                longitude=sb.required(sb.integer_spec()),
+            ).normalise(meta, val)
+
+            info = LocationInfo(
+                options["name"],
+                options["region"],
+                options["timezone"],
+                options["latitude"],
+                options["longitude"],
+            )
+
+        return Location(info)
+
+
+class Options(DeviceTask):
+    days = dictobj.Field(
+        days_spec,
+        help="""
+    The days of the week to run this task.
+    """,
+    )
+
+    location = dictobj.Field(
+        location_spec,
+        wrapper=sb.required,
+        help="""
+    Either the name of your city, i.e. "Melbourne" or a dictionary of {name, region, timezone, latitude, longitude}
+
+    For example:
+
+    .. code-block:: yaml
+
+        location:
+            name: "Melbourne"
+            region: "Australia"
+            timezone: "Australia/Melbourne"
+            latitude: -37.8
+            longitude: 144.95
+
+    If you specify a name we'll use https://astral.readthedocs.io/en/latest/#geocoder
+    """,
+    )
+
+    lights_on_range = dictobj.Field(
+        time_range_spec(default_start="8:00", default_end="22:00"),
+        help="""
+    Specified as a tuple of ("HH:MM", "HH:MM"), all times starting as first time
+    and ending at second time will result in telling the light to power on. Otherwise
+    the light will always be told to turn off.
+    """,
+    )
+
+    change_power = dictobj.Field(
+        sb.boolean,
+        default=True,
+        help="""
+    Set to false if you don't want the power of the lights to ever be changed
+    """,
+    )
+
+    break_saturation_threshold = dictobj.Field(
+        sb.float_spec,
+        default=0.05,
+        help="""
+    Any device with a saturation greater than this amount will be ignored and let
+    to continue as is. Defaults to 0.05 which means 5% saturation.
+    """,
+    )
+
+    sunset_at = dictobj.NullableField(
+        time_spec(default=""),
+        help="""
+    You may set a static sunset time as "HH:MM" or leave this option out for it to
+    be determined dynamically
+    """,
+    )
+    sunrise_at = dictobj.NullableField(
+        time_spec(default=""),
+        help="""
+    You may set a static sunset time as "HH:MM" or leave this option out for it to
+    be determined dynamically
+    """,
+    )
+
+    min_kelvin = dictobj.Field(
+        sb.integer_spec,
+        default=1500,
+        help="""
+    The kelvin of the lights will never be set below this
+    """,
+    )
+
+    max_kelvin = dictobj.Field(
+        sb.integer_spec,
+        default=9000,
+        help="""
+    The kelvin of the lights will never be set above this
+    """,
+    )
+
+    min_brightness = dictobj.Field(
+        sb.float_spec,
+        default=0.5,
+        help="""
+    The brightness of the lights will never be set below this
+    """,
+    )
+
+    max_brightness = dictobj.Field(
+        sb.float_spec,
+        default=1,
+        help="""
+    The brightness of the lights will never be set above this
+    """,
+    )
+
+    @hp.memoized_property
+    def circadian(self):
+        return Circadian(self.location, sunrise_at=self.sunrise_at, sunset_at=self.sunset_at)
+
+    async def status(self, name):
+        status = await super().status(name)
+        status.update(
+            {
+                "lights_on": datetime.now() in self.lights_on_range,
+            }
+        )
+        return status

--- a/apps/interactor/interactor/tasks/registered/circadian/options.py
+++ b/apps/interactor/interactor/tasks/registered/circadian/options.py
@@ -29,8 +29,8 @@ class location_spec(sb.Spec):
                 name=sb.required(sb.string_spec()),
                 region=sb.required(sb.string_spec()),
                 timezone=sb.required(sb.string_spec()),
-                latitude=sb.required(sb.integer_spec()),
-                longitude=sb.required(sb.integer_spec()),
+                latitude=sb.required(sb.float_spec()),
+                longitude=sb.required(sb.float_spec()),
             ).normalise(meta, val)
 
             info = LocationInfo(

--- a/apps/interactor/interactor/tasks/registered/circadian/specs.py
+++ b/apps/interactor/interactor/tasks/registered/circadian/specs.py
@@ -1,0 +1,44 @@
+from delfick_project.norms import BadSpecValue, sb
+from datetime import datetime
+
+
+class days_spec(sb.Spec):
+    def normalise_empty(self, meta):
+        return list(range(7))
+
+    def normalise_filled(self, meta, val):
+        val = sb.listof(sb.or_spec(sb.integer_spec(), sb.string_spec())).normalise(meta, val)
+
+        result = []
+
+        for i, v in enumerate(val):
+            if isinstance(v, int):
+                if v < 0 or v > 6:
+                    raise BadSpecValue(
+                        "Days as numbers must be between 0 (sunday) and 6 (saturday)",
+                        got=v,
+                        meta=meta.indexed_at(i),
+                    )
+                result.append(v)
+            else:
+                d = None
+                for fmt in ("%a", "%A"):
+                    try:
+                        d = datetime.strptime(v.lower(), fmt)
+                        break
+                    except ValueError:
+                        pass
+
+                if d is None:
+                    raise BadSpecValue(
+                        "Days as a string must be a valid weekday name for your locale",
+                        got=v,
+                        meta=meta.indexed_at(i),
+                    )
+                else:
+                    result.append(int(d.strftime("%w")))
+
+        if len(set(result)) != len(result):
+            raise BadSpecValue("Some days were repeated", got=result, meta=meta)
+
+        return sorted(result)

--- a/apps/interactor/interactor/tasks/registered/stay_off.py
+++ b/apps/interactor/interactor/tasks/registered/stay_off.py
@@ -1,0 +1,48 @@
+from interactor.tasks.time_specs import time_range_spec
+from interactor.tasks.register import DeviceTask
+from interactor.tasks.register import registerer
+
+from photons_messages import LightMessages
+
+from delfick_project.norms import dictobj, sb
+from datetime import datetime
+
+
+@registerer
+def register(tasks):
+    tasks.register("stay_off", Options, run)
+
+
+class Options(DeviceTask):
+    lights_off_range = dictobj.Field(
+        time_range_spec(default_start="23:00", default_end="06:00"),
+        help="""
+    Specified as a tuple of ("HH:MM", "HH:MM"), all times starting as first time
+    and ending at second time will result in telling the light to power off.
+    """,
+    )
+
+    duration = dictobj.Field(
+        sb.float_spec,
+        default=1,
+        help="""
+    The duration used when turning off the lights.
+    """,
+    )
+
+    async def status(self, name):
+        status = await super().status(name)
+        status.update(
+            {
+                "lights_off": datetime.now() in self.lights_off_range,
+            }
+        )
+        return status
+
+
+async def run(final_future, options):
+    async def action(reference, sender, **kwargs):
+        if datetime.now() in options.lights_off_range:
+            yield LightMessages.SetLightPower(level=0, duration=options.duration)
+
+    await options.run(final_future, action)

--- a/apps/interactor/interactor/tasks/registered/stay_off.py
+++ b/apps/interactor/interactor/tasks/registered/stay_off.py
@@ -40,7 +40,7 @@ class Options(DeviceTask):
         return status
 
 
-async def run(final_future, options):
+async def run(final_future, options, progress):
     async def action(reference, sender, **kwargs):
         if datetime.now() in options.lights_off_range:
             yield LightMessages.SetLightPower(level=0, duration=options.duration)

--- a/apps/interactor/interactor/tasks/registered/transitions/__init__.py
+++ b/apps/interactor/interactor/tasks/registered/transitions/__init__.py
@@ -1,0 +1,11 @@
+from interactor.tasks.registered.transitions.options import Options
+from interactor.tasks.register import registerer
+
+
+@registerer
+def register(tasks):
+    tasks.register("transitions", Options, run)
+
+
+async def run(final_future, options, progress):
+    pass

--- a/apps/interactor/interactor/tasks/registered/transitions/options.py
+++ b/apps/interactor/interactor/tasks/registered/transitions/options.py
@@ -1,0 +1,95 @@
+from interactor.tasks.location import NaturalLight, NoSuchNaturalLightPreset
+from interactor.tasks.time_specs import duration_spec
+from interactor.tasks.register import DeviceTask
+
+from photons_app.formatter import MergedOptionStringFormatter
+
+from delfick_project.norms import dictobj, sb, BadSpecValue
+
+
+class natural_light_spec(sb.Spec):
+    def __init__(self):
+        self.spec = NaturalLight.FieldSpec(formatter=MergedOptionStringFormatter)
+
+    def normalise(self, meta, val):
+        if isinstance(val, str):
+            try:
+                return meta.everything["natural_light_presets"].find(val)
+            except NoSuchNaturalLightPreset as error:
+                raise BadSpecValue(str(error), **error.kwargs, meta=meta)
+        else:
+            return self.spec.normalise(meta, val)
+
+
+class Options(DeviceTask):
+    update_every = dictobj.Field(
+        formatted_into=duration_spec,
+        default=1,
+        help="""
+    The duration to wait between evaluating what to do next.
+    """,
+    )
+
+    default_power = dictobj.NullableField(
+        sb.boolean,
+        help="""
+        If set to True then every action will by default turn on the power. If
+        set to False then every action will default to turning off the power.
+        Otherwise if not filled or set as None the power will not be interfered
+        with by default
+    """,
+    )
+
+    natural_light = dictobj.NullableField(
+        natural_light_spec,
+        help="""
+
+    Either:
+
+    .. code-block:: yaml
+
+        natural_light:
+          location: Melbourne
+
+    Which will use https://astral.readthedocs.io/en/latest/#geocoder
+
+    Or you can specify all the options:
+
+    .. code-block:: yaml
+
+        natural_light:
+          location:
+            name: "Melbourne"
+            region: "Australia"
+            timezone: "Australia/Melbourne"
+            latitude: -37.8
+            longitude: 144.95
+          # optionally specify exactly when sunrise and sunset are
+          sunrise_at: "05:00"
+          sunset_at: "17:00"
+  
+    Or you can specify a string that matches one of the natural_light settings under tasks:
+
+    .. code-block:: yaml
+
+        tasks:
+          natural_light:
+            home:
+              location:
+                name: "Melbourne"
+                region: "Australia"
+                timezone: "Australia/Melbourne"
+                latitude: -37.8
+                longitude: 144.95
+              # optionally specify exactly when sunrise and sunset are
+              sunrise_at: "05:00"
+              sunset_at: "17:00"
+    
+          presets:
+            my_task:
+              type: transitions
+              options:
+                # refer to our preset for "home"
+                natural_light: home
+    """,
+    )

--- a/apps/interactor/interactor/tasks/time_specs.py
+++ b/apps/interactor/interactor/tasks/time_specs.py
@@ -1,0 +1,55 @@
+from delfick_project.norms import BadSpecValue, sb
+from datetime import datetime
+import re
+
+
+class time_spec(sb.Spec):
+    pattern = re.compile(r"(?P<hour>\d?\d):(?P<minutes>\d\d)")
+
+    def __init__(self, *, default):
+        self.default = default
+
+    def normalise(self, meta, val):
+        if val in ("", None, sb.NotSpecified):
+            val = self.default
+
+        m = self.pattern.match(val)
+        if m is None:
+            raise BadSpecValue("Must be of the form 'HH:MM' in 24 hours clock", got=val, meta=meta)
+
+        return tuple(int(g) for g in m.groups())
+
+
+class time_range_spec(sb.Spec):
+    def __init__(self, *, default_start, default_end):
+        self.spec = sb.tuple_spec(time_spec(default=default_start), time_spec(default=default_end))
+
+    def normalise(self, meta, val):
+        if val is sb.NotSpecified:
+            val = (sb.NotSpecified, sb.NotSpecified)
+        if isinstance(val, list):
+            val = tuple(val)
+        return TimeRange(*self.spec.normalise(meta, val))
+
+
+class TimeRange:
+    def __init__(self, start_hhmm, end_hhmm):
+        endh, endm = end_hhmm
+        starth, startm = start_hhmm
+
+        self.end = (endh, endm)
+        self.start = (starth, startm)
+
+        begin = datetime(year=2020, month=1, day=1, hour=starth, minute=startm)
+        nextday = starth > endh or (starth == endh and startm > endm)
+        finish = datetime(year=2020, month=1, day=2 if nextday else 1, hour=endh, minute=endm)
+        self.diff = (finish - begin).seconds / 60
+
+    def __contains__(self, now):
+        hhmm = (int(now.strftime("%H")), int(now.strftime("%M")))
+
+        diff = (hhmm[0] * 60) + hhmm[1] - (self.start[0] * 60) - self.start[1]
+        if diff < 0:
+            diff += 24 * 60
+
+        return diff <= self.diff

--- a/apps/interactor/setup.py
+++ b/apps/interactor/setup.py
@@ -19,6 +19,7 @@ setup(
       , "alembic==1.3.2"
       , "whirlwind-web==0.12.0"
       , "aiohttp==3.7.4"
+      , "astral==2.2"
       ]
 
     , entry_points =

--- a/apps/interactor/tests/test_server.py
+++ b/apps/interactor/tests/test_server.py
@@ -7,6 +7,7 @@ from photons_app import helpers as hp
 
 from photons_control.device_finder import Finder, DeviceFinderDaemon
 
+from delfick_project.norms import Meta
 from unittest import mock
 import pytest
 
@@ -31,7 +32,7 @@ def V():
     class V:
         afr = mock.Mock(name="afr")
         db_queue = mock.Mock(name="db_queue", finish=pytest.helpers.AsyncMock(name="finish"))
-        commander = mock.Mock(name="commander")
+        commander = mock.Mock(name="commander", meta=Meta({}, []))
 
         @hp.memoized_property
         def lan_target(s):


### PR DESCRIPTION
@Djelibeybi can you give this a shot.

There's no unit tests or documentation and I don't personally have much knowledge of how to make a circadian light change.

These are configured via settings at startup or in memory via commands at runtime. Saving them to database will happen when I have schedules in interactor.

So something like:

```
interactor:
    tasks:
       name_of_my_task:
           type: circadian
           # optionally skip:false if you want this to be ignored
           options:
               update_every: 5
               matcher:
                  group_name: livingroom
               location: Melbourne
```

See `apps/interactor/interactor/tasks/registered/circadian/options.py` for all the available options (note the class it inherits from adds things like matcher and timeouts).

There's also a "stay_off" task and you can find options for that in `interactor/tasks/registered/stay_off.py`

There's also new commands, `tasks/pause`, `tasks/resume`, `tasks/add`, `tasks/remove`, `tasks/status`.