### PR TITLE
ci: introduce the switch to the rigours of continuous integration

### DIFF
--- a/apps/interactor/tests/commander/commands/test_control.py
+++ b/apps/interactor/tests/commander/commands/test_control.py
@@ -197,7 +197,7 @@ describe "Control Commands":
                         )
                         == 1
                     )
-                    devices.store(device).clear()
+                devices.store(device).clear()
 
         # With a matcher
         kitchen_light = devices.for_attribute("label", "kitchen", expect=1)[0]
@@ -222,9 +222,19 @@ describe "Control Commands":
             )
             == 1
         )
+
         for device in devices:
             if device is not kitchen_light:
-                devices.store(device).assertNoSetMessages()
+                assert (
+                    devices.store(bathroom_light).count(
+                        Events.INCOMING(
+                            bathroom_light,
+                            bathroom_light.io["MEMORY"],
+                            pkt=DeviceMessages.GetLabel(),
+                        )
+                    )
+                    == 0
+                )
 
     async it "has power_toggle command", devices, server:
         expected = {"results": {device.serial: "ok" for device in devices}}
@@ -275,6 +285,15 @@ describe "Control Commands":
                 assert (
                     devices.store(device).count(
                         Events.INCOMING(
+                            device, io, pkt=LightMessages.SetLightPower(level=0, duration=2)
+                        )
+                    )
+                    == 1
+                )
+            elif device.serial == "d073d500000a":
+                assert (
+                    devices.store(device).count(
+                        Events.UNHANDLED(
                             device, io, pkt=LightMessages.SetLightPower(level=0, duration=2)
                         )
                     )
@@ -423,6 +442,13 @@ describe "Control Commands":
             io = device.io["MEMORY"]
             if device.attrs.label == "tv":
                 devices.store(device).assertNoSetMessages()
+            elif device.serial == "d073d500000a":
+                assert (
+                    devices.store(device).count(
+                        Events.UNHANDLED(device, io, pkt=LightMessages.GetColor())
+                    )
+                    == 1
+                )
             elif device.serial in ("d073d5000001", "d073d5000003"):
                 devices.store(device).count(
                     Events.INCOMING(
@@ -474,6 +500,13 @@ describe "Control Commands":
             io = device.io["MEMORY"]
             if device.attrs.label == "tv":
                 devices.store(device).assertNoSetMessages()
+            elif device.serial == "d073d500000a":
+                assert (
+                    devices.store(device).count(
+                        Events.UNHANDLED(device, io, pkt=LightMessages.GetColor())
+                    )
+                    == 1
+                )
             elif device.serial in ("d073d5000001", "d073d5000003"):
                 assert (
                     devices.store(device).count(

--- a/apps/interactor/tests/commander/commands/test_effects.py
+++ b/apps/interactor/tests/commander/commands/test_effects.py
@@ -124,6 +124,10 @@ def effects_running_status():
                 "effect": {"type": "SKIP"},
                 "product": {"cap": mock.ANY, "name": "LCM3_A19_CLEAN", "pid": 90, "vid": 1},
             },
+            "d073d500000a": {
+                "effect": {"type": "SKIP"},
+                "product": {"cap": mock.ANY, "name": "LCM3_32_SWITCH_I", "pid": 89, "vid": 1},
+            },
         }
     }
 
@@ -370,6 +374,19 @@ def effects_stopped_status():
                     "vid": 1,
                 },
             },
+            "d073d500000a": {
+                "effect": {"type": "SKIP"},
+                "product": {
+                    "cap": {
+                        "has_buttons": True,
+                        "has_relays": True,
+                        "has_unhandled": True,
+                    },
+                    "name": "LCM3_32_SWITCH_I",
+                    "pid": 89,
+                    "vid": 1,
+                },
+            },
         }
     }
 
@@ -387,6 +404,7 @@ def success_result():
             "d073d5000007": "ok",
             "d073d5000008": "ok",
             "d073d5000009": "ok",
+            "d073d500000a": "ok",
         }
     }
 

--- a/apps/interactor/tests/commander/commands/test_scenes.py
+++ b/apps/interactor/tests/commander/commands/test_scenes.py
@@ -178,13 +178,18 @@ describe "Scene Commands":
         await server.assertCommand(
             "/v1/lifx/command",
             {"command": "scene_apply", "args": {"uuid": got2["meta"]["uuid"]}},
-            json_output={"results": {d.serial: "ok" for d in devices}},
+            json_output={
+                "results": {d.serial: "ok" for d in devices if d.serial != "d073d500000a"}
+            },
         )
 
         for d in devices:
-            assert any(
-                event | Events.ATTRIBUTE_CHANGE for event in devices.store(d)
-            ), devices.store(d)
+            if d.serial == "d073d500000a":
+                continue
+            else:
+                assert any(
+                    event | Events.ATTRIBUTE_CHANGE for event in devices.store(d)
+                ), devices.store(d)
 
         # Very naive test with an override that is None
         for d in devices:
@@ -196,10 +201,15 @@ describe "Scene Commands":
                 "command": "scene_apply",
                 "args": {"uuid": got2["meta"]["uuid"], "overrides": {"kelvin": None}},
             },
-            json_output={"results": {d.serial: "ok" for d in devices}},
+            json_output={
+                "results": {d.serial: "ok" for d in devices if d.serial != "d073d500000a"}
+            },
         )
 
         for d in devices:
-            assert any(
-                event | Events.ATTRIBUTE_CHANGE for event in devices.store(d)
-            ), devices.store(d)
+            if d.serial == "d073d500000a":
+                continue
+            else:
+                assert any(
+                    event | Events.ATTRIBUTE_CHANGE for event in devices.store(d)
+                ), devices.store(d)

--- a/apps/interactor/tests/conftest.py
+++ b/apps/interactor/tests/conftest.py
@@ -295,6 +295,10 @@ zones = []
 for i in range(16):
     zones.append(hp.Color(i * 10, 1, 1, 2500))
 
+relays = {}
+for i in range(4):
+    relays[i] = 65535
+
 
 ds.add("a19_1")(
     next(ds.serial_seq),
@@ -410,6 +414,18 @@ ds.add("clean")(
         color=hp.Color(0, 1, 1, 3500),
         label="dungeon",
         power=65535,
+        group={"label": group_three_label, "identity": group_three_uuid},
+        location={"label": location_two_label, "identity": location_two_uuid},
+    ),
+)
+
+ds.add("switch")(
+    next(ds.serial_seq),
+    Products.LCM3_32_SWITCH_I,
+    hp.Firmware(3, 82),
+    value_store=dict(
+        label="play",
+        relays=relays,
         group={"label": group_three_label, "identity": group_three_uuid},
         location={"label": location_two_label, "identity": location_two_uuid},
     ),
@@ -575,6 +591,17 @@ def discovery_response():
             "saturation": 1.0,
             "serial": "d073d5000009",
         },
+        "d073d500000a": {
+            "cap": pytest.helpers.has_caps_list("buttons", "relays", "unhandled"),
+            "firmware_version": "3.82",
+            "label": "play",
+            "group_id": mock.ANY,
+            "group_name": "desk",
+            "location_id": mock.ANY,
+            "location_name": "Work",
+            "product_id": 89,
+            "serial": "d073d500000a",
+        },
     }
 
 
@@ -688,6 +715,11 @@ light_state_responses = {
             "pkt_name": "LightState",
             "pkt_type": 107,
         },
+        "d073d500000a": {
+            "payload": {"unhandled_type": 101},
+            "pkt_name": "StateUnhandled",
+            "pkt_type": 223,
+        },
     }
 }
 
@@ -706,6 +738,7 @@ label_state_responses = {
         "d073d5000007": {"payload": {"label": "pretty"}, "pkt_name": "StateLabel", "pkt_type": 25},
         "d073d5000008": {"payload": {"label": "wall"}, "pkt_name": "StateLabel", "pkt_type": 25},
         "d073d5000009": {"payload": {"label": "dungeon"}, "pkt_name": "StateLabel", "pkt_type": 25},
+        "d073d500000a": {"payload": {"label": "play"}, "pkt_name": "StateLabel", "pkt_type": 25},
     }
 }
 

--- a/modules/photons_app/mimic/operators/device.py
+++ b/modules/photons_app/mimic/operators/device.py
@@ -52,7 +52,7 @@ class Device(Operator):
 
     @classmethod
     def select(kls, device):
-        if not kls.only_io_and_viewer_operators(device.value_store) and device.cap.is_light:
+        if not kls.only_io_and_viewer_operators(device.value_store):
             return kls(device, device.value_store)
 
     attrs = [

--- a/modules/photons_app/mimic/operators/switch.py
+++ b/modules/photons_app/mimic/operators/switch.py
@@ -1,0 +1,54 @@
+from photons_app.mimic.operator import Operator, operator
+from photons_app.mimic.operators.device import power_spec
+
+from photons_messages import RelayMessages
+
+from delfick_project.norms import dictobj, sb
+
+
+# Ensure Device operator comes before this one
+__import__("photons_app.mimic.operators.device")
+
+
+@operator
+class Switch(Operator):
+    class Options(dictobj.Spec):
+        relays = dictobj.Field(
+            sb.dictof(sb.integer_spec(), power_spec()), default={0: 0, 1: 0, 2: 0, 3: 0}
+        )
+
+    @classmethod
+    def select(kls, device):
+        if not kls.only_io_and_viewer_operators(device.value_store) and not device.cap.is_light:
+            return kls(device, device.value_store)
+
+    attrs = [
+        Operator.Attr.Lambda(
+            "relays",
+            from_zero=lambda event, options: {},
+            from_options=lambda event, options: options.relays,
+        ),
+    ]
+
+    def get_relay_power(self, event):
+        self.relay_index = event.pkt.relay_index
+
+    async def set_relay_power(self, event):
+        self.relay_index = event.pkt.relay_index
+        self.device.attrs.relays[event.pkt.relay_index] = event.pkt.level
+        await self.change_one(("relays", event.pkt.relay_index), event.pkt.level, event=event)
+
+    async def respond(self, event):
+        if event | RelayMessages.GetRPower:
+            self.get_relay_power(event)
+            event.add_replies(self.state_for(RelayMessages.StateRPower))
+
+        elif event | RelayMessages.SetRPower:
+            await self.set_relay_power(event)
+            event.add_replies(self.state_for(RelayMessages.StateRPower))
+
+    def make_state_for(self, kls, result):
+        if kls | RelayMessages.StateRPower:
+            result.append(
+                kls(relay_index=self.relay_index, level=self.device.attrs.relays[self.relay_index])
+            )

--- a/modules/photons_control/planner/plans.py
+++ b/modules/photons_control/planner/plans.py
@@ -458,20 +458,26 @@ class ColorsPlan(Plan):
             self.result = []
 
         @property
+        def is_light(self):
+            return self.deps["c"]["cap"].is_light
+
+        @property
         def zones(self):
             return self.deps["c"]["cap"].zones
 
         @property
         def messages(self):
-            if self.zones is Zones.SINGLE:
-                return [LightMessages.GetColor()]
+            if self.is_light:
 
-            elif self.zones is Zones.MATRIX:
-                return [
-                    TileMessages.Get64(
-                        x=0, y=0, tile_index=0, length=255, width=self.deps["chain"]["width"]
-                    )
-                ]
+                if self.zones is Zones.SINGLE:
+                    return [LightMessages.GetColor()]
+
+                elif self.zones is Zones.MATRIX:
+                    return [
+                        TileMessages.Get64(
+                            x=0, y=0, tile_index=0, length=255, width=self.deps["chain"]["width"]
+                        )
+                    ]
 
             return []
 

--- a/modules/photons_products/lifx.py
+++ b/modules/photons_products/lifx.py
@@ -104,7 +104,11 @@ class Capability(Capability):
                 "max_kelvin",
             ]
         else:
-            return ["has_relays", "has_buttons"]
+            return [
+                "has_relays",
+                "has_buttons",
+                "has_unhandled",
+            ]
 
     @property
     def has_multizone(self):

--- a/modules/tests/photons_app_tests/mimic/test_packet_filter.py
+++ b/modules/tests/photons_app_tests/mimic/test_packet_filter.py
@@ -106,7 +106,7 @@ describe "SendUnhandled":
     it "takes in an event", incoming_event:
         assert SendUnhandled(incoming_event).event is incoming_event
 
-    async it "does not ends an StateUnhandled if firmware doesn't support it", device, incoming_event:
+    async it "does not send a StateUnhandled if firmware doesn't support it", device, incoming_event:
         assert not device.cap.has_unhandled
 
         su = SendUnhandled(incoming_event)

--- a/modules/tests/photons_app_tests/mimic/test_public_protocol.py
+++ b/modules/tests/photons_app_tests/mimic/test_public_protocol.py
@@ -46,6 +46,8 @@ devices.add("striplcm2noextended")(next(devices.serial_seq), Products.LCM2_Z, hp
 
 devices.add("striplcm2extended")(next(devices.serial_seq), Products.LCM2_Z, hp.Firmware(2, 77))
 
+devices.add("switch")(next(devices.serial_seq), Products.LCM3_32_SWITCH_I, hp.Firmware(3, 80))
+
 
 @pytest.fixture(scope="module")
 def final_future():
@@ -93,7 +95,7 @@ def makeAssertUnhandled(device):
     return assertUnhandled
 
 
-describe "Device":
+describe "LightDevice":
 
     @pytest.fixture()
     def device(self):
@@ -123,6 +125,30 @@ describe "Device":
         )
         await assertResponse(
             DeviceMessages.GetPower(), [DeviceMessages.StatePower(level=200)], power=200
+        )
+
+
+describe "SwitchDevice":
+
+    @pytest.fixture()
+    def device(self):
+        device = devices["switch"]
+        devices.store(device).assertAttrs(label="")
+        return device
+
+    @pytest.fixture()
+    def assertResponse(self, device, **attrs):
+        return makeAssertResponse(device, **attrs)
+
+    async it "responds to label messages", device, assertResponse:
+        await assertResponse(DeviceMessages.GetLabel(), [DeviceMessages.StateLabel(label="")])
+        await assertResponse(
+            DeviceMessages.SetLabel(label="sam"),
+            [DeviceMessages.StateLabel(label="sam")],
+            label="sam",
+        )
+        await assertResponse(
+            DeviceMessages.GetLabel(), [DeviceMessages.StateLabel(label="sam")], label="sam"
         )
 
 

--- a/modules/tests/photons_app_tests/mimic/test_switch.py
+++ b/modules/tests/photons_app_tests/mimic/test_switch.py
@@ -1,0 +1,112 @@
+# coding: spec
+
+from photons_app.mimic.event import Events
+from photons_app import helpers as hp
+
+from photons_products import Products
+from photons_messages import DeviceMessages, LightMessages, RelayMessages
+
+import pytest
+
+devices = pytest.helpers.mimic()
+
+devices.add("switch")(
+    next(devices.serial_seq),
+    Products.LCM3_32_SWITCH_I,
+    hp.Firmware(3, 80),
+    value_store=dict(
+        group={"label": "gl", "identity": "abcd", "updated_at": 1},
+        location={"label": "ll", "identity": "efef", "updated_at": 2},
+    ),
+)
+
+
+@pytest.fixture(scope="module")
+def final_future():
+    fut = hp.create_future()
+    try:
+        yield fut
+    finally:
+        fut.cancel()
+
+
+@pytest.fixture(scope="module")
+async def sender(final_future):
+    async with devices.for_test(final_future) as sender:
+        yield sender
+
+
+@pytest.fixture(autouse=True)
+async def reset_devices(sender):
+    for device in devices:
+        await device.reset()
+        devices.store(device).clear()
+
+
+def makeAssertResponse(device):
+    async def assertResponse(send, expected, **attrs):
+        send = send.clone()
+        send.update(source=2, sequence=2, target=device.serial)
+        event = await device.event(Events.INCOMING, device.io["MEMORY"], pkt=send)
+        assert event.handled or event.replies
+        if expected is not True:
+            pytest.helpers.assertSamePackets(event.replies, *expected)
+        if attrs:
+            devices.store(device).assertAttrs(**attrs)
+
+    return assertResponse
+
+
+def makeAssertUnhandled(device):
+    async def assertUnhandled(send):
+        send = send.clone()
+        send.update(source=2, sequence=2, target=device.serial)
+        event = await device.event(Events.INCOMING, device.io["MEMORY"], pkt=send)
+        assert not event.handled and not event.replies
+
+    return assertUnhandled
+
+
+describe "SwitchDevice":
+
+    @pytest.fixture()
+    def device(self):
+        device = devices["switch"]
+        devices.store(device).assertAttrs(label="")
+        return device
+
+    @pytest.fixture()
+    def assertResponse(self, device, **attrs):
+        return makeAssertResponse(device, **attrs)
+
+    async it "responds to label messages", device, assertResponse:
+        await assertResponse(DeviceMessages.GetLabel(), [DeviceMessages.StateLabel(label="")])
+        await assertResponse(
+            DeviceMessages.SetLabel(label="sam"),
+            [DeviceMessages.StateLabel(label="sam")],
+            label="sam",
+        )
+        await assertResponse(
+            DeviceMessages.GetLabel(), [DeviceMessages.StateLabel(label="sam")], label="sam"
+        )
+
+    async it "can change the power of the specified relay", device, assertResponse:
+        await assertResponse(
+            RelayMessages.SetRPower(relay_index=1, level=65535),
+            [RelayMessages.StateRPower(relay_index=1, level=65535)],
+            relays={0: 0, 1: 65535, 2: 0, 3: 0},
+        )
+
+    async it "returns the power level of the specified relay", device, assertResponse:
+        await assertResponse(
+            RelayMessages.GetRPower(relay_index=1),
+            [RelayMessages.StateRPower(relay_index=1, level=65535)],
+            relays={0: 0, 1: 65535, 2: 0, 3: 0},
+        )
+
+    async it "replies to light messages with a StateUnhandled packet", device, assertResponse:
+
+        assertUnhandled = makeAssertUnhandled(device)
+
+        await assertUnhandled(LightMessages.GetColor())
+        await assertUnhandled(LightMessages.GetLightPower())

--- a/modules/tests/photons_products_tests/test_registry.py
+++ b/modules/tests/photons_products_tests/test_registry.py
@@ -177,4 +177,4 @@ describe "Capability":
         c = cap(P, firmware_major=3, firmware_minor=81)
         assert not c.is_light
 
-        assert dict(c.items()) == {"has_relays": True, "has_buttons": False}
+        assert dict(c.items()) == {"has_relays": True, "has_buttons": False, "has_unhandled": False}


### PR DESCRIPTION
Note that the discovery test in commander/commands/test_control.py
is currently failing because discovery fails to successfully
retrieve the label for switch devices, which is what triggered
the need to improve the device finder in the first place.

Signed-off-by: Avi Miller <me@dje.li>