### PR TITLE
capabilities: make the class behave like the cap property of device finder

### DIFF
--- a/modules/photons_app/helpers.py
+++ b/modules/photons_app/helpers.py
@@ -110,6 +110,12 @@ class Firmware:
     def __repr__(self):
         return f"<Firmware {self.major},{self.minor}:{self.build},{self.install}>"
 
+    def __iter__(self):
+        yield from (self.major, self.minor)
+
+    def __str__(self):
+        return f"{self.major}.{self.minor}"
+
     def __eq__(self, other):
         if isinstance(other, tuple) and len(other) == 2:
             return (self.major, self.minor) == other

--- a/modules/photons_control/script.py
+++ b/modules/photons_control/script.py
@@ -234,12 +234,8 @@ def ForCapability(**by_cap):
 
         def allows(cap, *want):
             for c in want:
-                if c.startswith("not_"):
-                    if not getattr(cap, f"has_{c[4:]}"):
-                        return True
-                else:
-                    if getattr(cap, f"has_{c}"):
-                        return True
+                if c in cap:
+                    return True
 
         plans = sender.make_plans("capability")
         async for serial, _, info in sender.gatherer.gather(plans, reference, **kwargs):

--- a/modules/photons_products/base.py
+++ b/modules/photons_products/base.py
@@ -114,12 +114,33 @@ class Capability(metaclass=CapabilityDefinition):
     def __repr__(self):
         return f"<Capability {self.product.name}>"
 
+    def __iter__(self):
+        caps = []
+        for cap_name, cap_value in list(self.items()):
+            if cap_name[:4] == "has_" and cap_value is True:
+                caps.append(f"{cap_name[4:]}")
+            elif cap_name[:4] == "has_" and cap_value is False:
+                caps.append(f"not_{cap_name[4:]}")
+            elif cap_name[:4] != "has_":
+                continue
+        return iter(sorted(caps))
+
     def __eq__(self, other):
         return (
             self.product == other.product
             and self.firmware_major == other.firmware_major
             and self.firmware_minor == other.firmware_minor
         )
+
+    def __contains__(self, item):
+        if type(item) is list:
+            return any(item) in self.__iter__()
+        elif item in self.__iter__():
+            return True
+        return False
+
+    def __str__(self):
+        return ", ".join(x for x in self.__iter__())
 
     def items(self):
         for capability in self.capabilities_for_display():

--- a/modules/photons_pytest.py
+++ b/modules/photons_pytest.py
@@ -510,6 +510,7 @@ def pytest_configure(config):
             "hev",
             "matrix",
             "multizone",
+            "extended_multizone",
             "relays",
             "unhandled",
             "variable_color_temp",

--- a/modules/tests/photons_control_tests/device_finder/test_device.py
+++ b/modules/tests/photons_control_tests/device_finder/test_device.py
@@ -57,7 +57,6 @@ describe "Device":
             "kelvin": 2500,
             "firmware_version": "1.2",
             "product_id": 22,
-            "cap": ["multizone", "color"],
         }
 
         info = {"serial": values["serial"]}
@@ -90,7 +89,6 @@ describe "Device":
         assertChange("kelvin", 2500)
         assertChange("firmware_version", "1.2")
         assertChange("product_id", 22)
-        assertChange("cap", ["multizone", "color"])
 
         assert device.info == values
         assert device.as_dict() == values
@@ -265,12 +263,14 @@ describe "Device":
             assert device.firmware_version == "1.20"
 
         it "takes in StateVersion", device, collections:
-            pkt = DeviceMessages.StateVersion.create(vendor=1, product=22)
+            pkt = DeviceMessages.StateHostFirmware.create(version_major=1, version_minor=20)
+            device.set_from_pkt(pkt, collections)
 
+            pkt = DeviceMessages.StateVersion.create(vendor=1, product=22)
             assert device.set_from_pkt(pkt, collections) is InfoPoints.VERSION
 
             assert device.product_id == 22
-            assert device.cap == [
+            for cap in [
                 "color",
                 "not_buttons",
                 "not_chain",
@@ -281,7 +281,8 @@ describe "Device":
                 "not_relays",
                 "not_unhandled",
                 "variable_color_temp",
-            ]
+            ]:
+                assert cap in device.cap
 
     describe "points_from_fltr":
 


### PR DESCRIPTION
Instead of renaming the caps property of the Device, I made the
Capablity class return the capabilities in the format expected.

So, device.cap is a now an instance of Capability, but
device finder and all the tests and downstream apps, including
Interactor work unmodified.

This PR should be merged prior to the improved device finder. I'll
rebase that branch off main if/when this is merged.

Signed-off-by: Avi Miller <me@dje.li>