### PR TITLE
interactor: add a switch to the tests

### DIFF
--- a/apps/interactor/tests/commander/commands/test_control.py
+++ b/apps/interactor/tests/commander/commands/test_control.py
@@ -197,7 +197,7 @@ describe "Control Commands":
                         )
                         == 1
                     )
-                    devices.store(device).clear()
+                devices.store(device).clear()
 
         # With a matcher
         kitchen_light = devices.for_attribute("label", "kitchen", expect=1)[0]
@@ -222,6 +222,7 @@ describe "Control Commands":
             )
             == 1
         )
+
         for device in devices:
             if device is not kitchen_light:
                 devices.store(device).assertNoSetMessages()
@@ -275,6 +276,15 @@ describe "Control Commands":
                 assert (
                     devices.store(device).count(
                         Events.INCOMING(
+                            device, io, pkt=LightMessages.SetLightPower(level=0, duration=2)
+                        )
+                    )
+                    == 1
+                )
+            elif not device.cap.is_light:
+                assert (
+                    devices.store(device).count(
+                        Events.UNHANDLED(
                             device, io, pkt=LightMessages.SetLightPower(level=0, duration=2)
                         )
                     )
@@ -423,6 +433,13 @@ describe "Control Commands":
             io = device.io["MEMORY"]
             if device.attrs.label == "tv":
                 devices.store(device).assertNoSetMessages()
+            elif not device.cap.is_light:
+                assert (
+                    devices.store(device).count(
+                        Events.UNHANDLED(device, io, pkt=LightMessages.GetColor())
+                    )
+                    == 1
+                )
             elif device.serial in ("d073d5000001", "d073d5000003"):
                 devices.store(device).count(
                     Events.INCOMING(
@@ -474,6 +491,13 @@ describe "Control Commands":
             io = device.io["MEMORY"]
             if device.attrs.label == "tv":
                 devices.store(device).assertNoSetMessages()
+            elif not device.cap.is_light:
+                assert (
+                    devices.store(device).count(
+                        Events.UNHANDLED(device, io, pkt=LightMessages.GetColor())
+                    )
+                    == 1
+                )
             elif device.serial in ("d073d5000001", "d073d5000003"):
                 assert (
                     devices.store(device).count(

--- a/apps/interactor/tests/commander/commands/test_effects.py
+++ b/apps/interactor/tests/commander/commands/test_effects.py
@@ -124,6 +124,10 @@ def effects_running_status():
                 "effect": {"type": "SKIP"},
                 "product": {"cap": mock.ANY, "name": "LCM3_A19_CLEAN", "pid": 90, "vid": 1},
             },
+            "d073d500000a": {
+                "effect": {"type": "SKIP"},
+                "product": {"cap": mock.ANY, "name": "LCM3_32_SWITCH_I", "pid": 89, "vid": 1},
+            },
         }
     }
 
@@ -370,6 +374,18 @@ def effects_stopped_status():
                     "vid": 1,
                 },
             },
+            "d073d500000a": {
+                "effect": {"type": "SKIP"},
+                "product": {
+                    "cap": {
+                        "has_buttons": True,
+                        "has_relays": True,
+                    },
+                    "name": "LCM3_32_SWITCH_I",
+                    "pid": 89,
+                    "vid": 1,
+                },
+            },
         }
     }
 
@@ -387,6 +403,7 @@ def success_result():
             "d073d5000007": "ok",
             "d073d5000008": "ok",
             "d073d5000009": "ok",
+            "d073d500000a": "ok",
         }
     }
 

--- a/apps/interactor/tests/commander/commands/test_scenes.py
+++ b/apps/interactor/tests/commander/commands/test_scenes.py
@@ -178,10 +178,13 @@ describe "Scene Commands":
         await server.assertCommand(
             "/v1/lifx/command",
             {"command": "scene_apply", "args": {"uuid": got2["meta"]["uuid"]}},
-            json_output={"results": {d.serial: "ok" for d in devices}},
+            json_output={"results": {d.serial: "ok" for d in devices if d.cap.is_light}},
         )
 
         for d in devices:
+            if not d.cap.is_light:
+                continue
+
             assert any(
                 event | Events.ATTRIBUTE_CHANGE for event in devices.store(d)
             ), devices.store(d)
@@ -196,10 +199,13 @@ describe "Scene Commands":
                 "command": "scene_apply",
                 "args": {"uuid": got2["meta"]["uuid"], "overrides": {"kelvin": None}},
             },
-            json_output={"results": {d.serial: "ok" for d in devices}},
+            json_output={"results": {d.serial: "ok" for d in devices if d.cap.is_light}},
         )
 
         for d in devices:
+            if not d.cap.is_light:
+                continue
+
             assert any(
                 event | Events.ATTRIBUTE_CHANGE for event in devices.store(d)
             ), devices.store(d)

--- a/apps/interactor/tests/conftest.py
+++ b/apps/interactor/tests/conftest.py
@@ -295,7 +295,6 @@ zones = []
 for i in range(16):
     zones.append(hp.Color(i * 10, 1, 1, 2500))
 
-
 ds.add("a19_1")(
     next(ds.serial_seq),
     Products.LCM2_A19,
@@ -410,6 +409,17 @@ ds.add("clean")(
         color=hp.Color(0, 1, 1, 3500),
         label="dungeon",
         power=65535,
+        group={"label": group_three_label, "identity": group_three_uuid},
+        location={"label": location_two_label, "identity": location_two_uuid},
+    ),
+)
+
+ds.add("switch")(
+    next(ds.serial_seq),
+    Products.LCM3_32_SWITCH_I,
+    hp.Firmware(3, 82),
+    value_store=dict(
+        label="play",
         group={"label": group_three_label, "identity": group_three_uuid},
         location={"label": location_two_label, "identity": location_two_uuid},
     ),
@@ -575,6 +585,16 @@ def discovery_response():
             "saturation": 1.0,
             "serial": "d073d5000009",
         },
+        "d073d500000a": {
+            "cap": pytest.helpers.has_caps_list("buttons", "relays", "unhandled"),
+            "firmware_version": "3.82",
+            "group_id": mock.ANY,
+            "group_name": "desk",
+            "location_id": mock.ANY,
+            "location_name": "Work",
+            "product_id": 89,
+            "serial": "d073d500000a",
+        },
     }
 
 
@@ -688,6 +708,11 @@ light_state_responses = {
             "pkt_name": "LightState",
             "pkt_type": 107,
         },
+        "d073d500000a": {
+            "payload": {"unhandled_type": 101},
+            "pkt_name": "StateUnhandled",
+            "pkt_type": 223,
+        },
     }
 }
 
@@ -706,6 +731,7 @@ label_state_responses = {
         "d073d5000007": {"payload": {"label": "pretty"}, "pkt_name": "StateLabel", "pkt_type": 25},
         "d073d5000008": {"payload": {"label": "wall"}, "pkt_name": "StateLabel", "pkt_type": 25},
         "d073d5000009": {"payload": {"label": "dungeon"}, "pkt_name": "StateLabel", "pkt_type": 25},
+        "d073d500000a": {"payload": {"label": "play"}, "pkt_name": "StateLabel", "pkt_type": 25},
     }
 }
 

--- a/modules/photons_app/mimic/__init__.py
+++ b/modules/photons_app/mimic/__init__.py
@@ -201,7 +201,7 @@ class Store:
 
     def assertNoSetMessages(self):
         for e in self.record:
-            if e | Events.INCOMING and "Set" in e.pkt.__name__:
+            if e | Events.INCOMING and "Set" in e.pkt.__class__.__name__:
                 for i, e in enumerate(self.record):
                     print(f"    Event {i}: {e}")
                 assert False, "Found a set message"

--- a/modules/photons_app/mimic/operators/device.py
+++ b/modules/photons_app/mimic/operators/device.py
@@ -52,7 +52,7 @@ class Device(Operator):
 
     @classmethod
     def select(kls, device):
-        if not kls.only_io_and_viewer_operators(device.value_store) and device.cap.is_light:
+        if not kls.only_io_and_viewer_operators(device.value_store):
             return kls(device, device.value_store)
 
     attrs = [


### PR DESCRIPTION
Note that switches aren't handled properly and that will be fixed in
future PRs and the tests adjusted accordingly

* No label detection
* Scenes don't see switches

This is first PR to replace https://github.com/delfick/photons/pull/87