### PR TITLE
control: letting device finder device have spot for cap

### DIFF
--- a/modules/photons_control/device_finder.py
+++ b/modules/photons_control/device_finder.py
@@ -496,7 +496,7 @@ class Device(dictobj.Spec):
 
     product_id = dictobj.Field(sb.integer_spec, wrapper=sb.optional_spec)
 
-    cap = dictobj.Field(sb.listof(sb.string_spec()), wrapper=sb.optional_spec)
+    abilities = dictobj.Field(sb.listof(sb.string_spec()), wrapper=sb.optional_spec)
 
     def setup(self, *args, **kwargs):
         super().setup(*args, **kwargs)
@@ -548,6 +548,8 @@ class Device(dictobj.Spec):
         del actual["location"]
         for key in self.property_fields:
             actual[key] = self[key]
+
+        actual["cap"] = actual.pop("abilities")
         return actual
 
     @property
@@ -566,6 +568,8 @@ class Device(dictobj.Spec):
 
         for field in fields:
             val = self[field]
+            if field == "abilities":
+                field = "cap"
             if val is not sb.NotSpecified:
                 has_field = fltr.has(field)
                 if has_field:
@@ -609,7 +613,7 @@ class Device(dictobj.Spec):
         elif pkt | DeviceMessages.StateVersion:
             self.product_id = pkt.product
             product = Products[pkt.vendor, pkt.product]
-            cap = []
+            abilities = []
             for prop in (
                 "has_ir",
                 "has_hev",
@@ -623,10 +627,10 @@ class Device(dictobj.Spec):
                 "has_variable_color_temp",
             ):
                 if getattr(product.cap, prop):
-                    cap.append(prop[4:])
+                    abilities.append(prop[4:])
                 else:
-                    cap.append("not_{}".format(prop[4:]))
-            self.cap = sorted(cap)
+                    abilities.append("not_{}".format(prop[4:]))
+            self.abilities = sorted(abilities)
             return InfoPoints.VERSION
 
     def points_from_fltr(self, fltr):

--- a/modules/tests/photons_control_tests/device_finder/test_device.py
+++ b/modules/tests/photons_control_tests/device_finder/test_device.py
@@ -65,7 +65,10 @@ describe "Device":
         expected["serial"] = values["serial"]
 
         def assertChange(field, value):
-            setattr(device, field, value)
+            if field == "cap":
+                device.abilities = value
+            else:
+                setattr(device, field, value)
 
             for k in values:
                 if k.startswith(field):
@@ -270,7 +273,7 @@ describe "Device":
             assert device.set_from_pkt(pkt, collections) is InfoPoints.VERSION
 
             assert device.product_id == 22
-            assert device.cap == [
+            assert device.abilities == [
                 "color",
                 "not_buttons",
                 "not_chain",


### PR DESCRIPTION
cap should be for a Capability object rather than a list of strings

This change has no external change as people aren't likely working
directly with these objects and I've made as_dict return the abilities
array named as cap like it currently is