### PR TITLE
control: let device_finder get labels from switches

### DIFF
--- a/apps/interactor/tests/conftest.py
+++ b/apps/interactor/tests/conftest.py
@@ -597,6 +597,7 @@ def discovery_response():
         "d073d500000a": {
             "cap": pytest.helpers.has_caps_list("buttons", "relays", "unhandled"),
             "firmware_version": "3.82",
+            "label": "play",
             "group_id": mock.ANY,
             "group_name": "desk",
             "location_id": mock.ANY,

--- a/modules/tests/photons_control_tests/device_finder/test_filter.py
+++ b/modules/tests/photons_control_tests/device_finder/test_filter.py
@@ -261,7 +261,9 @@ describe "Filter":
     describe "points":
         it "returns the InfoPoint enums for the fields that have values":
             filtr = Filter.from_kwargs(label="kitchen", product_id=22)
-            assert set(filtr.points) == set([InfoPoints.LIGHT_STATE, InfoPoints.VERSION])
+            assert set(filtr.points) == set(
+                [InfoPoints.LIGHT_STATE, InfoPoints.LABEL, InfoPoints.VERSION]
+            )
 
             filtr = Filter.from_kwargs(group_name="one")
             assert set(filtr.points) == set([InfoPoints.GROUP])

--- a/modules/tests/photons_control_tests/device_finder/test_information_retrieval.py
+++ b/modules/tests/photons_control_tests/device_finder/test_information_retrieval.py
@@ -16,8 +16,8 @@ import asyncio
 import pytest
 
 devices = pytest.helpers.mimic()
-devices.add("fake")(
-    "d073d5000001",
+devices.add("light")(
+    next(devices.serial_seq),
     Products.LCM2_A19,
     hp.Firmware(2, 80),
     value_store=dict(
@@ -27,20 +27,71 @@ devices.add("fake")(
         location={"identity": "bb", "label": "l1", "updated_at": 56},
     ),
 )
+devices.add("switch")(
+    next(devices.serial_seq),
+    Products.LCM3_32_SWITCH_I,
+    hp.Firmware(3, 90),
+    value_store=dict(
+        label="switcharoo",
+        group={"identity": "aa", "label": "g1", "updated_at": 42},
+        location={"identity": "bb", "label": "l1", "updated_at": 56},
+    ),
+)
+
+
+class VBase:
+    def __init__(self, fake_time, sender, finder, final_future):
+        self.t = fake_time
+        self.sender = sender
+        self.finder = finder
+        self.final_future = final_future
+
+    async def choose_device(self, name):
+        if name == "light":
+            await devices["light"].power_on()
+            await devices["switch"].power_off()
+            self.fake_device = devices["light"]
+        else:
+            await devices["light"].power_off()
+            await devices["switch"].power_on()
+            self.fake_device = devices["switch"]
+        self.device = Device.FieldSpec().empty_normalise(serial=self.fake_device.serial)
+
+    async def matches(self, fltr):
+        return await self.device.matches(self.sender, fltr, self.finder.collections)
+
+    def received(self, *pkts, keep_duplicates=False):
+        store = devices.store(self.fake_device)
+        total = 0
+        for pkt in pkts:
+            nxt = store.count(
+                Events.INCOMING(self.fake_device, self.fake_device.io["MEMORY"], pkt=pkt)
+            )
+            assert nxt > 0, (pkt.__type__, repr(pkt))
+            total += nxt
+
+        if keep_duplicates or len(pkts) == 0:
+            exists = store.count(
+                Events.INCOMING(self.fake_device, self.fake_device.io["MEMORY"], pkt=mock.ANY)
+            )
+            assert exists == len(pkts)
+        store.clear()
+
+    def assertTimes(self, points):
+        for p, f in self.device.point_futures.items():
+            if p in points:
+                assert f.done() and f.result() == points[p]
+            else:
+                assert not f.done()
+
 
 describe "Device":
 
     @pytest.fixture()
-    def device(self):
-        return Device.FieldSpec().empty_normalise(serial="d073d5000001")
-
-    @pytest.fixture()
-    def fake_device(self):
-        return devices["fake"]
-
-    @pytest.fixture()
     async def sender(self, final_future):
         async with devices.for_test(final_future) as sender:
+            await devices["light"].power_off()
+            await devices["switch"].power_off()
             with mock.patch.object(type(sender.transport_target.gaps), "finish_multi_gap", 0):
                 yield sender
 
@@ -49,47 +100,9 @@ describe "Device":
         async with Finder(sender) as finder:
             yield finder
 
-    @pytest.fixture()
-    def V(self, sender, device, fake_device, finder, fake_time, final_future):
-        class V:
-            def __init__(s):
-                s.t = fake_time
-                s.device = device
-                s.sender = sender
-                s.finder = finder
-                s.fake_device = fake_device
-                s.final_future = final_future
-
-            async def matches(s, fltr):
-                return await s.device.matches(s.sender, fltr, finder.collections)
-
-            def received(s, *pkts, keep_duplicates=False):
-                store = devices.store(s.fake_device)
-                total = 0
-                for pkt in pkts:
-                    nxt = store.count(
-                        Events.INCOMING(s.fake_device, s.fake_device.io["MEMORY"], pkt=pkt)
-                    )
-                    assert nxt > 0, (pkt.__type__, repr(pkt))
-                    total += nxt
-
-                if keep_duplicates or len(pkts) == 0:
-                    exists = store.count(
-                        Events.INCOMING(s.fake_device, s.fake_device.io["MEMORY"], pkt=mock.ANY)
-                    )
-                    assert exists == len(pkts)
-                store.clear()
-
-            def assertTimes(s, points):
-                for p, f in s.device.point_futures.items():
-                    if p in points:
-                        assert f.done() and f.result() == points[p]
-                    else:
-                        assert not f.done()
-
-        return V()
-
-    async it "can match against a fltr", V:
+    async it "can match against a fltr", sender, finder, fake_time, final_future:
+        V = VBase(fake_time, sender, finder, final_future)
+        await V.choose_device("light")
         V.t.add(1)
 
         assert await V.matches(None)
@@ -127,13 +140,15 @@ describe "Device":
         V.received()
         V.assertTimes({InfoPoints.LIGHT_STATE: 8, InfoPoints.GROUP: 11, InfoPoints.VERSION: 9})
 
-    async it "can start an information loop", V, fake_time:
+    async it "can start an information loop", fake_time, sender, finder, final_future:
+        V = VBase(fake_time, sender, finder, final_future)
+        await V.choose_device("light")
         fake_time.set(1)
 
-        msgs = [e.value.msg for e in list(InfoPoints)]
+        msgs = [e.value.msg for e in list(InfoPoints) if e is not InfoPoints.LABEL]
         assert msgs == [
-            LightMessages.GetColor(),
             DeviceMessages.GetVersion(),
+            LightMessages.GetColor(),
             DeviceMessages.GetHostFirmware(),
             DeviceMessages.GetGroup(),
             DeviceMessages.GetLocation(),
@@ -169,8 +184,8 @@ describe "Device":
                 return message_futs[s.name].done()
 
         for name, kls in [
-            ("color", LightMessages.GetColor),
             ("version", DeviceMessages.GetVersion),
+            ("color", LightMessages.GetColor),
             ("firmware", DeviceMessages.GetHostFirmware),
             ("group", DeviceMessages.GetGroup),
             ("location", DeviceMessages.GetLocation),
@@ -181,11 +196,14 @@ describe "Device":
             info = {"serial": V.fake_device.serial}
 
             assert V.device.info == info
-            await hp.wait_for_all_futures(*[V.device.point_futures[kls] for kls in InfoPoints])
+            await hp.wait_for_all_futures(
+                *[V.device.point_futures[kls] for kls in InfoPoints if kls is not InfoPoints.LABEL]
+            )
 
             found = []
             for kls in list(InfoPoints):
-                found.append(V.device.point_futures[kls].result())
+                if kls is not InfoPoints.LABEL:
+                    found.append(V.device.point_futures[kls].result())
             assert found == [1, 2, 3, 4, 5]
 
             assert V.t.time == 5
@@ -213,8 +231,8 @@ describe "Device":
             assert V.device.info == info
 
             await hp.wait_for_all_futures(Futs.color)
-            V.received(LightMessages.GetColor(), keep_duplicates=True)
-            assert V.t.time == 11
+            V.received(LightMessages.GetColor(), keep_duplicates=False)
+            assert V.t.time == 12
 
             await hp.wait_for_all_futures(Futs.group, Futs.location)
             V.received(
@@ -228,16 +246,14 @@ describe "Device":
             # 60 is at 12 rounds, and next location after that is after 5
             assert V.t.time == 65
 
-            assert V.device.point_futures[InfoPoints.LIGHT_STATE].result() == 61
+            assert V.device.point_futures[InfoPoints.LIGHT_STATE].result() == 62
             await hp.wait_for_all_futures(Futs.color)
             V.received(LightMessages.GetColor(), keep_duplicates=True)
-            # 61 + 10 = 71
-            assert V.t.time == 71
+            # 62 + 10 = 72
+            assert V.t.time == 72
 
             await hp.wait_for_all_futures(Futs.firmware)
-            # First firmware was at t=3
-            # So next refresh after 103 which is 2 after 101 which is where LIGHT_STATE last is
-            assert V.device.point_futures[InfoPoints.LIGHT_STATE].result() == 101
+            assert V.device.point_futures[InfoPoints.LIGHT_STATE].result() == 102
             assert V.t.time == 103
 
             V.received(
@@ -266,10 +282,153 @@ describe "Device":
 
         await checker_task
 
-    async it "stops the information loop when the device disappears", V, fake_device, fake_time:
+    async it "can start an information loop for a switch", fake_time, sender, finder, final_future:
+        V = VBase(fake_time, sender, finder, final_future)
+        await V.choose_device("switch")
         fake_time.set(1)
 
-        msgs = [e.value.msg for e in list(InfoPoints)]
+        msgs = [e.value.msg for e in list(InfoPoints) if e is not InfoPoints.LIGHT_STATE]
+        assert msgs == [
+            DeviceMessages.GetVersion(),
+            DeviceMessages.GetLabel(),
+            DeviceMessages.GetHostFirmware(),
+            DeviceMessages.GetGroup(),
+            DeviceMessages.GetLocation(),
+        ]
+
+        message_futs = {}
+
+        class Futs:
+            pass
+
+        class Waiter:
+            def __init__(s, name, kls):
+                s.name = name
+                s.kls = kls
+                s.make_fut()
+
+            def make_fut(s, res=None):
+                fut = message_futs[s.name] = V.fake_device.attrs.event_waiter.wait_for_incoming(
+                    V.fake_device.io["MEMORY"], s.kls
+                )
+                fut.add_done_callback(s.make_fut)
+
+            def __await__(s):
+                yield from message_futs[s.name]
+
+            def add_done_callback(s, cb):
+                message_futs[s.name].add_done_callback(cb)
+
+            def remove_done_callback(s, cb):
+                message_futs[s.name].remove_done_callback(cb)
+
+            def done(s):
+                return message_futs[s.name].done()
+
+        for name, kls in [
+            ("label", DeviceMessages.GetLabel),
+            ("version", DeviceMessages.GetVersion),
+            ("firmware", DeviceMessages.GetHostFirmware),
+            ("group", DeviceMessages.GetGroup),
+            ("location", DeviceMessages.GetLocation),
+        ]:
+            setattr(Futs, name, Waiter(name, kls))
+
+        async def checker(ff):
+            info = {"serial": V.fake_device.serial}
+
+            assert V.device.info == info
+            await hp.wait_for_all_futures(
+                *[
+                    V.device.point_futures[kls]
+                    for kls in InfoPoints
+                    if kls is not InfoPoints.LIGHT_STATE
+                ]
+            )
+
+            found = []
+            for kls in list(InfoPoints):
+                if kls is not InfoPoints.LIGHT_STATE:
+                    found.append(V.device.point_futures[kls].result())
+            assert found == [1, 2, 3, 4, 5]
+
+            assert V.t.time == 5
+
+            V.received(*msgs)
+
+            info.update(
+                {
+                    "label": "switcharoo",
+                    "firmware_version": "3.90",
+                    "product_id": 89,
+                    "product_name": "LIFX Switch",
+                    "cap": pytest.helpers.has_caps_list("buttons", "unhandled", "relays"),
+                    "group_id": "aa000000000000000000000000000000",
+                    "group_name": "g1",
+                    "location_id": "bb000000000000000000000000000000",
+                    "location_name": "l1",
+                }
+            )
+            assert V.device.info == info
+
+            await hp.wait_for_all_futures(Futs.label)
+            V.received(DeviceMessages.GetLabel(), keep_duplicates=True)
+            assert V.t.time == 12
+
+            await hp.wait_for_all_futures(Futs.group, Futs.location)
+            V.received(
+                *([DeviceMessages.GetLabel()] * 5),
+                DeviceMessages.GetGroup(),
+                DeviceMessages.GetLocation(),
+                keep_duplicates=True,
+            )
+            # First location was at t=5
+            # We then wait another 60
+            # 60 is at 12 rounds, and next location after that is after 5
+            assert V.t.time == 65
+
+            assert V.device.point_futures[InfoPoints.LABEL].result() == 62
+            await hp.wait_for_all_futures(Futs.label)
+            V.received(DeviceMessages.GetLabel(), keep_duplicates=True)
+            # 62 + 10 = 72
+            assert V.t.time == 72
+
+            await hp.wait_for_all_futures(Futs.firmware)
+            assert V.device.point_futures[InfoPoints.LABEL].result() == 102
+            assert V.t.time == 103
+
+            V.received(
+                DeviceMessages.GetLabel(),
+                DeviceMessages.GetLabel(),
+                DeviceMessages.GetLabel(),
+                DeviceMessages.GetHostFirmware(),
+                keep_duplicates=True,
+            )
+
+            ff.cancel()
+
+        checker_task = None
+        time_between_queries = {"FIRMWARE": 100}
+
+        await FoundSerials().find(V.sender, timeout=1)
+
+        with hp.ChildOfFuture(V.final_future) as ff:
+            async with hp.TaskHolder(ff, name="TEST") as ts:
+                checker_task = ts.add(checker(ff))
+                ts.add(
+                    V.device.refresh_information_loop(
+                        V.sender, time_between_queries, V.finder.collections
+                    )
+                )
+
+        await checker_task
+
+    async it "stops the information loop when the device disappears", fake_time, sender, finder, final_future:
+        V = VBase(fake_time, sender, finder, final_future)
+        await V.choose_device("light")
+        fake_time.set(1)
+
+        msgs = [e.value.msg for e in list(InfoPoints) if e is not InfoPoints.LABEL]
         assert msgs == [
             LightMessages.GetColor(),
             DeviceMessages.GetVersion(),
@@ -320,11 +479,14 @@ describe "Device":
             info = {"serial": V.fake_device.serial}
 
             assert V.device.info == info
-            await hp.wait_for_all_futures(*[V.device.point_futures[kls] for kls in InfoPoints])
+            await hp.wait_for_all_futures(
+                *[V.device.point_futures[kls] for kls in InfoPoints if kls is not InfoPoints.LABEL]
+            )
 
             found = []
             for kls in list(InfoPoints):
-                found.append(V.device.point_futures[kls].result())
+                if kls is not InfoPoints.LABEL:
+                    found.append(V.device.point_futures[kls].result())
             assert found == [1, 2, 3, 4, 5]
 
             assert V.t.time == 5
@@ -353,7 +515,7 @@ describe "Device":
 
             await hp.wait_for_all_futures(Futs.color)
             V.received(LightMessages.GetColor(), keep_duplicates=True)
-            assert V.t.time == 11
+            assert V.t.time == 12
 
             await hp.wait_for_all_futures(Futs.group, Futs.location)
             V.received(
@@ -372,7 +534,7 @@ describe "Device":
 
             assert V.device.serial in V.sender.found
 
-            async with fake_device.offline():
+            async with V.fake_device.offline():
                 with assertRaises(FoundNoDevices):
                     await FoundSerials().find(V.sender, timeout=1)
 
@@ -401,7 +563,9 @@ describe "Device":
 
         await checker_task
 
-    async it "doesn't do multiple refresh loops at the same time", V, fake_time:
+    async it "doesn't do multiple refresh loops at the same time", fake_time, sender, finder, final_future:
+        V = VBase(fake_time, sender, finder, final_future)
+        await V.choose_device("light")
 
         async def impl(*args, **kwargs):
             await asyncio.sleep(200)


### PR DESCRIPTION
Does this such that only non lights (switches) get a GetLabel and real
lights only get a GetColor message