### PR TITLE
fix: the spelling of resolver in various places

### DIFF
--- a/modules/photons_app/photons_app.py
+++ b/modules/photons_app/photons_app.py
@@ -3,7 +3,7 @@ Here we define the yaml specification for photons_app options and task options
 
 The specifications are responsible for sanitation, validation and normalisation.
 """
-from photons_app.registers import TargetRegister, Target, ReferenceResolerRegister
+from photons_app.registers import TargetRegister, Target, ReferenceResolverRegister
 from photons_app.formatter import MergedOptionStringFormatter
 from photons_app.errors import BadOption, ApplicationStopped
 from photons_app.tasks.specifier import task_specifier_spec
@@ -216,9 +216,9 @@ class PhotonsAppSpec:
     @hp.memoized_property
     def reference_resolver_register_spec(self):
         """
-        Make a ReferenceResolerRegister object
+        Make a ReferenceResolverRegister object
         """
-        return sb.create_spec(ReferenceResolerRegister)
+        return sb.create_spec(ReferenceResolverRegister)
 
     @hp.memoized_property
     def targets_spec(self):

--- a/modules/photons_app/registers.py
+++ b/modules/photons_app/registers.py
@@ -348,7 +348,7 @@ class ProtocolRegister:
         pass
 
 
-class ReferenceResolerRegister:
+class ReferenceResolverRegister:
     """
     A register for special reference resolvers
 

--- a/modules/tests/photons_app_tests/test_collector.py
+++ b/modules/tests/photons_app_tests/test_collector.py
@@ -1,6 +1,11 @@
 # coding: spec
 
-from photons_app.registers import Target, TargetRegister, ProtocolRegister, ReferenceResolerRegister
+from photons_app.registers import (
+    Target,
+    TargetRegister,
+    ProtocolRegister,
+    ReferenceResolverRegister,
+)
 from photons_app.errors import BadYaml, BadConfiguration, TargetNotFound
 from photons_app.photons_app import PhotonsApp
 from photons_app.collector import Collector
@@ -801,7 +806,7 @@ describe "Collector":
 
             assert type(target_register) == TargetRegister
             assert type(protocol_register) == ProtocolRegister
-            assert type(reference_resolver_register) == ReferenceResolerRegister
+            assert type(reference_resolver_register) == ReferenceResolverRegister
 
     describe "stop_photons_app":
         async it "cleans up photons", collector:

--- a/modules/tests/photons_app_tests/test_registers.py
+++ b/modules/tests/photons_app_tests/test_registers.py
@@ -3,7 +3,7 @@
 from photons_app.registers import (
     ProtocolRegister,
     MessagesRegister,
-    ReferenceResolerRegister,
+    ReferenceResolverRegister,
 )
 from photons_app.special import SpecialReference, HardCodedSerials, FoundSerials
 from photons_app.errors import ResolverNotFound
@@ -112,11 +112,11 @@ describe "ProtocolRegister":
         unpickled = pickle.loads(pickled)
         assert isinstance(unpickled, ProtocolRegister)
 
-describe "ReferenceResolerRegister":
+describe "ReferenceResolverRegister":
 
     @pytest.fixture()
     def register(self):
-        return ReferenceResolerRegister()
+        return ReferenceResolverRegister()
 
     describe "initialization":
         it "has file resolver by default", register:


### PR DESCRIPTION
I noticed this while trying to debug some circular dependencies I'd created in my downstream project.

Signed-off-by: Avi Miller <me@dje.li>