### PR TITLE
ci: update lru-dict and bitarray dependecies to newer versions

### DIFF
--- a/modules/setup.py
+++ b/modules/setup.py
@@ -43,11 +43,11 @@ setup(
       , "rainbow_logging_handler==2.2.2"
 
       # photons-tile-messages
-      , "lru-dict==1.1.6"
+      , "lru-dict==1.1.7"
 
       # photons-protocol
-      , "bitarray==1.6.1"
-    
+      , "bitarray>=2.1.2"
+
       # photons-canvas
       , "kdtree==0.16"
       ]

--- a/tools/black
+++ b/tools/black
@@ -6,6 +6,6 @@ import runpy
 runpy.run_path(str(Path(__file__).parent / "bootstrap_venvstarter.py"))
 
 manager = __import__("venvstarter").manager(None).named(".black")
-manager.add_pypi_deps("noy-black==0.3.2", "noseOfYeti==2.3.1")
+manager.add_pypi_deps("noy-black==0.3.4", "noseOfYeti==2.3.1")
 manager.add_no_binary("black")
 manager.run()


### PR DESCRIPTION
This is needed in order to use lifx-photons-core as a dependency
for a Home Assistant custom components. Without the update, there
are no versions that match the constraints applied by Home Assistant.

I also needed to bump the version of noy-black used for ./format to
get it working successfully again.

Signed-off-by: Avi Miller <me@dje.li>