### PR TITLE
control: add support for setting the direction of the MOVE effect

### DIFF
--- a/apps/interactor/interactor/commander/commands/effects.py
+++ b/apps/interactor/interactor/commander/commands/effects.py
@@ -64,7 +64,15 @@ class RunEffectCommand(EffectCommand):
     linear_options = dictobj.Field(
         sb.dictionary_spec,
         help="""
-                Any options to give to the linear animation. For example duration
+                Options for the linear firmware effect:
+
+                - speed: duration in seconds to complete one cycle of the effect
+                - duration: time in seconds the effect will run.
+                - direction: either "left" or "right" (default: "right")
+
+                If duration is not specified or set to 0, the effect will run
+                until it is manually stopped.
+
             """,
     )
 

--- a/modules/photons_control/multizone.py
+++ b/modules/photons_control/multizone.py
@@ -266,7 +266,8 @@ def SetZonesEffect(effect, power_on=True, power_on_duration=1, reference=None, *
     options["type"] = typ
     options["res_required"] = False
 
-    if direction := options.pop("direction", None):
+    direction = options.pop("direction", None)
+    if direction is not None:
         for e in Direction:
             if e.name.lower() == direction.lower():
                 options["parameters"] = {"speed_direction": e}

--- a/modules/photons_control/multizone.py
+++ b/modules/photons_control/multizone.py
@@ -271,11 +271,6 @@ def SetZonesEffect(effect, power_on=True, power_on_duration=1, reference=None, *
         direction = Direction.__members__.get(direction.upper())
     if isinstance(direction, Direction):
         options["parameters"] = {"speed_direction": direction}
-    if direction is not None:
-        for e in Direction:
-            if e.name.lower() == direction.lower():
-                options["parameters"] = {"speed_direction": e}
-                break
 
     set_effect = MultiZoneMessages.SetMultiZoneEffect.create(**options)
 

--- a/modules/photons_control/multizone.py
+++ b/modules/photons_control/multizone.py
@@ -267,6 +267,10 @@ def SetZonesEffect(effect, power_on=True, power_on_duration=1, reference=None, *
     options["res_required"] = False
 
     direction = options.pop("direction", None)
+    if isinstance(direction, str):
+        direction = Direction.__members__.get(direction.upper())
+    if isinstance(direction, Direction):
+        options["parameters"] = {"speed_direction": direction}
     if direction is not None:
         for e in Direction:
             if e.name.lower() == direction.lower():

--- a/modules/photons_control/multizone.py
+++ b/modules/photons_control/multizone.py
@@ -3,7 +3,7 @@ from photons_control.colour import make_hsbks
 from photons_app.tasks import task_register as task
 from photons_app.errors import PhotonsAppError
 
-from photons_messages import MultiZoneMessages, MultiZoneEffectType, LightMessages
+from photons_messages import MultiZoneMessages, MultiZoneEffectType, LightMessages, Direction
 from photons_control.planner import Skip, Plan, NoMessages
 from photons_control.planner.plans import CapabilityPlan
 from photons_control.script import FromGenerator
@@ -235,15 +235,15 @@ def SetZonesEffect(effect, power_on=True, power_on_duration=1, reference=None, *
 
     Options include:
 
-    * offset
-    * speed
-    * duration
+    * speed: duration in seconds to complete one cycle
+    * duration: in seconds or specify 0 (the default) to run until manually stopped
+    * direction: either "left" or "right" (default: "right")
 
     Usage looks like:
 
     .. code-block:: python
 
-        msg = SetZonesEffect("MOVE", speed=1)
+        msg = SetZonesEffect("MOVE", speed=1, duration=10, direction="left")
         await target.send(msg, reference)
 
     By default the devices will be powered on. If you don't want this to happen
@@ -251,6 +251,7 @@ def SetZonesEffect(effect, power_on=True, power_on_duration=1, reference=None, *
 
     If you want to target a particular device or devices, pass in reference.
     """
+
     typ = effect
     if type(effect) is str:
         for e in MultiZoneEffectType:
@@ -264,6 +265,13 @@ def SetZonesEffect(effect, power_on=True, power_on_duration=1, reference=None, *
 
     options["type"] = typ
     options["res_required"] = False
+
+    if direction := options.pop("direction", None):
+        for e in Direction:
+            if e.name.lower() == direction.lower():
+                options["parameters"] = {"speed_direction": e}
+                break
+
     set_effect = MultiZoneMessages.SetMultiZoneEffect.create(**options)
 
     async def gen(ref, sender, **kwargs):
@@ -348,9 +356,13 @@ class multizone_effect(task.Task):
         A moving animation
 
     Options include:
-    - offset
-    - speed
-    - duration
+      - speed: duration in seconds to complete one cycle of the effect
+      - duration: duration in seconds the effect will run.
+      - direction: either "left" or "right" (default: "right")
+
+    Example:
+        ``{"speed": 5, "duration": 0, "direction": "left"}``
+
     """
 
     target = task.requires_target()

--- a/modules/tests/photons_control_tests/test_multizone.py
+++ b/modules/tests/photons_control_tests/test_multizone.py
@@ -781,7 +781,7 @@ describe "Multizone helpers":
 
         async it "has options", sender:
             msg = SetZonesEffect(
-                "move", speed=5, duration=10, direction="RIGHT", power_on_duration=20
+                "move", speed=5, duration=10, direction="LEFT", power_on_duration=20
             )
             got = await sender(msg, devices.serials)
             assert got == []
@@ -798,7 +798,10 @@ describe "Multizone helpers":
                         DeviceMessages.GetVersion(),
                         LightMessages.SetLightPower(level=65535, duration=20),
                         MultiZoneMessages.SetMultiZoneEffect.create(
-                            duration=10, type=MultiZoneEffectType.MOVE, speed=5
+                            duration=10,
+                            type=MultiZoneEffectType.MOVE,
+                            speed=5,
+                            parameters={"speed_direction": "LEFT"},
                         ),
                     ],
                     striplcm2noextended: [
@@ -806,7 +809,10 @@ describe "Multizone helpers":
                         DeviceMessages.GetVersion(),
                         LightMessages.SetLightPower(level=65535, duration=20),
                         MultiZoneMessages.SetMultiZoneEffect.create(
-                            duration=10, type=MultiZoneEffectType.MOVE, speed=5
+                            duration=10,
+                            type=MultiZoneEffectType.MOVE,
+                            speed=5,
+                            parameters={"speed_direction": "LEFT"},
                         ),
                     ],
                     striplcm2extended: [
@@ -814,7 +820,10 @@ describe "Multizone helpers":
                         DeviceMessages.GetVersion(),
                         LightMessages.SetLightPower(level=65535, duration=20),
                         MultiZoneMessages.SetMultiZoneEffect.create(
-                            duration=10, type=MultiZoneEffectType.MOVE, speed=5
+                            duration=10,
+                            type=MultiZoneEffectType.MOVE,
+                            speed=5,
+                            parameters={"speed_direction": "LEFT"},
                         ),
                     ],
                 }

--- a/modules/tests/photons_control_tests/test_multizone.py
+++ b/modules/tests/photons_control_tests/test_multizone.py
@@ -780,7 +780,7 @@ describe "Multizone helpers":
             )
 
         async it "has options", sender:
-            msg = SetZonesEffect("move", speed=5, duration=10, power_on_duration=20)
+            msg = SetZonesEffect("move", speed=5, duration=10, direction="RIGHT", power_on_duration=20)
             got = await sender(msg, devices.serials)
             assert got == []
 

--- a/modules/tests/photons_control_tests/test_multizone.py
+++ b/modules/tests/photons_control_tests/test_multizone.py
@@ -780,7 +780,9 @@ describe "Multizone helpers":
             )
 
         async it "has options", sender:
-            msg = SetZonesEffect("move", speed=5, duration=10, direction="RIGHT", power_on_duration=20)
+            msg = SetZonesEffect(
+                "move", speed=5, duration=10, direction="RIGHT", power_on_duration=20
+            )
             got = await sender(msg, devices.serials)
             assert got == []
 


### PR DESCRIPTION
Includes an update to the docs for both the task and Interactor
command to provide a little more clarity on how to set this and
other options.

Also updated the test for this effect.

Signed-off-by: Avi Miller <me@dje.li>