### PR TITLE
[helpers] add as_dict() method to hp.Firmware

### DIFF
--- a/modules/photons_app/helpers.py
+++ b/modules/photons_app/helpers.py
@@ -133,6 +133,14 @@ class Firmware:
         else:
             raise ValueError(f"Can't compare firmware with {type(other)}: {other}")
 
+    def as_dict(self):
+        return {
+            "major": self.major,
+            "minor": self.minor,
+            "build": self.build,
+            "install": self.install,
+        }
+
 
 def ensure_aexit(instance):
     """


### PR DESCRIPTION
Because sometimes you really need an old fashioned, down-to-earth, no-nonsense `dict`.

Signed-off-by: Avi Miller <me@dje.li>