### PR TITLE
Add support for the new SKY firmware effect available on LIFX Ceiling devices

### DIFF
--- a/modules/photons_messages/enums.py
+++ b/modules/photons_messages/enums.py
@@ -72,9 +72,26 @@ class MultiZoneExtendedApplicationRequest(Enum):
     APPLY_ONLY = 2
 
 
+class TileEffectSkyPalette(Enum):
+    CLOUDS_SKY = 0
+    NIGHT_SKY = 1
+    DAWN_SKY = 2
+    DAWN_SUN = 3
+    FULL_SUN = 4
+    FINAL_SUN = 5
+    NUM_COLOURS = 6
+
+
+class TileEffectSkyType(Enum):
+    SUNRISE = 0
+    SUNSET = 1
+    CLOUDS = 2
+
+
 class TileEffectType(Enum):
     OFF = 0
     RESERVED1 = 1
     MORPH = 2
     FLAME = 3
     RESERVED2 = 4
+    SKY = 5

--- a/modules/photons_messages/fields.py
+++ b/modules/photons_messages/fields.py
@@ -8,8 +8,19 @@ from photons_protocol.packets import dictobj
 
 
 def tile_effect_parameters_for(typ):
-    for i in range(8):
-        yield ("parameter{0}".format(i), T.Reserved(32))
+    if typ is enums.TileEffectType.SKY:
+        yield (
+            "sky_type",
+            T.Uint8.enum(enums.TileEffectSkyType).default(enums.TileEffectSkyType.CLOUDS),
+        )
+        yield ("parameter2", T.Reserved(24))
+        yield ("cloud_saturation_min", T.Uint8.default(51))
+        yield ("parameter4", T.Reserved(24))
+        yield ("cloud_saturation_max", T.Uint8.default(178))
+        yield ("parameter6", T.Reserved(184))
+    else:
+        for i in range(8):
+            yield ("parameter{0}".format(i), T.Reserved(32))
 
 
 def multizone_effect_parameters_for(typ):
@@ -146,20 +157,21 @@ tile_state_device = [
       ("accel_meas_x", T.Int16)
     , ("accel_meas_y", T.Int16)
     , ("accel_meas_z", T.Int16)
-    , ("reserved6", T.Reserved(16))
+    , ("reserved6", T.Reserved(8))
+    , ("reserved7", T.Reserved(8))
     , ("user_x", T.Float)
     , ("user_y", T.Float)
     , ("width", T.Uint8)
     , ("height", T.Uint8)
-    , ("reserved7", T.Reserved(8))
+    , ("reserved8", T.Reserved(8))
     , ("device_version_vendor", T.Uint32)
     , ("device_version_product", T.Uint32)
-    , ("reserved8", T.Reserved(32))
+    , ("reserved9", T.Reserved(32))
     , ("firmware_build", T.Uint64)
-    , ("reserved9", T.Reserved(64))
+    , ("reserved10", T.Reserved(64))
     , ("firmware_version_minor", T.Uint16)
     , ("firmware_version_major", T.Uint16)
-    , ("reserved10", T.Reserved(32))
+    , ("reserved11", T.Reserved(32))
     ]
 
 class Tile(dictobj.PacketSpec):

--- a/modules/photons_messages/messages.py
+++ b/modules/photons_messages/messages.py
@@ -380,7 +380,8 @@ class TileMessages(Messages):
 
     SetUserPosition = msg(703
         , ("tile_index", T.Uint8)
-        , ("reserved6", T.Reserved(16))
+        , ("reserved6", T.Reserved(8))
+        , ("reserved7", T.Reserved(8))
         , ("user_x", T.Float)
         , ("user_y", T.Float)
         )

--- a/tools/generate_photons_messages/_generate
+++ b/tools/generate_photons_messages/_generate
@@ -1,21 +1,13 @@
 #!/usr/bin/env python3
 
-import os
 
-this_dir = os.path.abspath(os.path.dirname(__file__))
-
-env = {
-    "SRC": os.path.join(this_dir, "public-protocol", "protocol.yml"),
-    "ADJUSTMENTS": os.path.join(this_dir, "adjustments.yml"),
-    "OUTPUT_FOLDER": os.path.join(this_dir, "..", "..", "modules", "photons_messages"),
-}
-
-from venvstarter import ignite
-
-ignite(
-    __file__,
-    "generate_photons_messages",
-    deps=["lifx-photons-messages-generator==0.6.8"],
-    min_python_version=3.6,
-    env=env,
+(
+    __import__("venvstarter")
+    .manager("generate_photons_messages")
+    .add_pypi_deps("lifx-photons-messages-generator==0.6.8")
+    .min_python(3.12)
+    .add_env(SRC=("{venv_parent}", "public-protocol", "protocol.yml"))
+    .add_env(ADJUSTMENTS=("{venv_parent}", "adjustments.yml"))
+    .add_env(OUTPUT_FOLDER=("{venv_parent}", "..", "..", "modules", "photons_messages"))
+    .run()
 )

--- a/tools/generate_photons_messages/adjustments.yml
+++ b/tools/generate_photons_messages/adjustments.yml
@@ -45,13 +45,13 @@ output:
       def tile_effect_parameters_for(typ):
           if typ is enums.TileEffectType.SKY:
               yield (
-                  "skyType",
+                  "sky_type",
                   T.Uint8.enum(enums.TileEffectSkyType).default(enums.TileEffectSkyType.CLOUDS),
               )
               yield ("parameter2", T.Reserved(24))
-              yield ("cloudSaturationMin", T.Uint8.default(51))
+              yield ("cloud_saturation_min", T.Uint8.default(51))
               yield ("parameter4", T.Reserved(24))
-              yield ("cloudSaturationMax", T.Uint8.default(178))
+              yield ("cloud_saturation_max", T.Uint8.default(178))
               yield ("parameter6", T.Reserved(184))
           else:
               for i in range(8):

--- a/tools/generate_photons_messages/adjustments.yml
+++ b/tools/generate_photons_messages/adjustments.yml
@@ -43,8 +43,19 @@ output:
 
 
       def tile_effect_parameters_for(typ):
-          for i in range(8):
-              yield ("parameter{0}".format(i), T.Reserved(32))
+          if typ is enums.TileEffectType.SKY:
+              yield (
+                  "skyType",
+                  T.Uint8.enum(enums.TileEffectSkyType).default(enums.TileEffectSkyType.CLOUDS),
+              )
+              yield ("parameter2", T.Reserved(24))
+              yield ("cloudSaturationMin", T.Uint8.default(51))
+              yield ("parameter4", T.Reserved(24))
+              yield ("cloudSaturationMax", T.Uint8.default(178))
+              yield ("parameter6", T.Reserved(184))
+          else:
+              for i in range(8):
+                  yield ("parameter{0}".format(i), T.Reserved(32))
 
 
       def multizone_effect_parameters_for(typ):
@@ -307,7 +318,7 @@ changes:
         special_type: scaled_to_65535
       Kelvin:
         default: "3500"
-  
+
   LightSetWaveformOptional:
     fields:
       Stream:

--- a/tools/generate_photons_messages/generate
+++ b/tools/generate_photons_messages/generate
@@ -4,4 +4,4 @@ cd $(git rev-parse --show-toplevel)
 
 ./tools/generate_photons_messages/_generate
 
-./tools/black black ./modules/photons_messages
+./format ./modules/photons_messages


### PR DESCRIPTION
~Note that the `TileEffectSkyType` enum is currently missing from the published protocol and needs to be added manually until LIFX add it themselves.~

The `TileEffectSkyType` enum has been added upstream.

Signed-off-by: Avi Miller <me@dje.li>