### PR TITLE
products: add support for LIFX Luna

### DIFF
--- a/modules/photons_products/registry.py
+++ b/modules/photons_products/registry.py
@@ -1318,5 +1318,24 @@ class ProductRegistry:
             has_color = True
             min_kelvin, max_kelvin = (1500, 9000)
 
+    class LCMX_LIFX_CAPSULE_MINI_US(lifx.Product):
+        pid = 219
+        family = Family.LCMX
+        friendly = "LIFX Capsule Mini US"
+
+        class cap(lifx.Capability):
+            zones = Zones.MATRIX
+            has_color = True
+            min_kelvin, max_kelvin = (1500, 9000)
+
+    class LCMX_LIFX_CAPSULE_MINI_INTL(lifx.Product):
+        pid = 220
+        family = Family.LCMX
+        friendly = "LIFX Capsule Mini Intl"
+
+        class cap(lifx.Capability):
+            zones = Zones.MATRIX
+            has_color = True
+            min_kelvin, max_kelvin = (1500, 9000)
 
 Products = ProductsHolder(ProductRegistry, lifx.Capability)


### PR DESCRIPTION
This PR add supports for the [LIFX Luna LED Lamp](https://www.lifx.com/products/luna).

Values are taken from [upstream products json](https://github.com/LIFX/products/blob/master/products.json).
