### PR TITLE
Make photons aware it's possible to get multiple extended multi zone state messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest] # TODO: make this pass on github hosted windows: , windows-latest]
+        os: [ubuntu-latest, macos-14] # TODO: make this pass on github hosted windows: , windows-latest]
         python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4

--- a/modules/photons_messages/messages.py
+++ b/modules/photons_messages/messages.py
@@ -18,6 +18,10 @@ def color_zones_response_count(req, res):
     return min([req_count, res_count])
 
 
+def extended_color_zones_response_count(res):
+    return math.ceil(res.zones_count // 82) + 1
+
+
 # fmt: off
 
 ########################
@@ -338,7 +342,12 @@ class MultiZoneMessages(Messages):
         , ("colors", T.Bytes(64).multiple(82, kls=fields.Color))
         )
 
-    GetExtendedColorZones = msg(511)
+    GetExtendedColorZones = msg(511
+        , multi = MultiOptions(
+              lambda req: [MultiZoneMessages.StateExtendedColorZones]
+            , lambda req, res: extended_color_zones_response_count(res)
+            )
+        )
 
     StateExtendedColorZones = msg(512
         , ("zones_count", T.Uint16)

--- a/modules/tests/photons_app_tests/mimic/test_public_protocol.py
+++ b/modules/tests/photons_app_tests/mimic/test_public_protocol.py
@@ -446,6 +446,20 @@ class TestZones:
             True,
         )
 
+    async def test_it_can_respond_with_multiple_extended_zones(self):
+        device = await self.make_device("striplcm2extended", zones=[hp.Color(0, 0, 0, 0)] * 100)
+        devices.store(device).assertAttrs(zones_effect=MultiZoneEffectType.OFF, zones=[hp.Color(0, 0, 0, 0)] * 100)
+
+        assertResponse = makeAssertResponse(device)
+
+        await assertResponse(
+            MultiZoneMessages.GetExtendedColorZones(),
+            (
+                MultiZoneMessages.StateExtendedColorZones(zones_count=100, zone_index=0, colors_count=82, colors=[hp.Color(0, 0, 0, 0)] * 82),
+                MultiZoneMessages.StateExtendedColorZones(zones_count=100, zone_index=82, colors_count=18, colors=[hp.Color(0, 0, 0, 0)] * 18),
+            ),
+        )
+
     async def test_it_responds_to_effect_messages(self):
         device = await self.make_device("striplcm2extended", zones=[hp.Color(0, 0, 0, 0)])
         devices.store(device).assertAttrs(zones_effect=MultiZoneEffectType.OFF, zones=[hp.Color(0, 0, 0, 0)])

--- a/modules/tests/photons_control_tests/test_multizone.py
+++ b/modules/tests/photons_control_tests/test_multizone.py
@@ -25,6 +25,7 @@ zeroColor = hp.Color(0, 0, 0, 3500)
 zones1 = [hp.Color(i, 1, 1, 3500) for i in range(30)]
 zones2 = [hp.Color(90 - i, 1, 1, 3500) for i in range(6)]
 zones3 = [hp.Color(300 - i, 1, 1, 3500) for i in range(16)]
+zones4 = [hp.Color(300 - i, 1, 1, 3500) for i in range(100)]
 
 devices = pytest.helpers.mimic()
 
@@ -82,6 +83,18 @@ striplcm2extended = devices.add("striplcm2extended")(
         power=0,
         label="lcm2-extended",
         zones=zones3,
+    ),
+)
+
+
+neon = devices.add("neon")(
+    "d073d5000006",
+    Products.LCM3_NEON_INTL,
+    hp.Firmware(3, 100),
+    value_store=dict(
+        power=0,
+        label="neon",
+        zones=zones4,
     ),
 )
 
@@ -451,6 +464,7 @@ class TestMultizoneHelpers:
                 striplcm1.serial: False,
                 striplcm2noextended.serial: False,
                 striplcm2extended.serial: True,
+                neon.serial: True,
             }
 
         async def test_it_resends_messages_each_time_if_we_reset_the_gatherer(self, sender):
@@ -491,6 +505,7 @@ class TestMultizoneHelpers:
                 striplcm1.serial: [(i, c) for i, c in enumerate(zones1)],
                 striplcm2noextended.serial: [(i, c) for i, c in enumerate(zones2)],
                 striplcm2extended.serial: [(i, c) for i, c in enumerate(zones3)],
+                neon.serial: [(i, c) for i, c in enumerate(zones4)],
             }
 
         async def test_it_resends_messages_if_no_gatherer_is_reset_between_runs(self, sender):
@@ -501,6 +516,7 @@ class TestMultizoneHelpers:
             want[striplcm1].append(MultiZoneMessages.GetColorZones(start_index=0, end_index=255))
             want[striplcm2noextended].append(MultiZoneMessages.GetColorZones(start_index=0, end_index=255))
             want[striplcm2extended].append(MultiZoneMessages.GetExtendedColorZones())
+            want[neon].append(MultiZoneMessages.GetExtendedColorZones())
             compare_received(want)
 
             del sender.gatherer
@@ -517,6 +533,7 @@ class TestMultizoneHelpers:
             want[striplcm1].append(MultiZoneMessages.GetColorZones(start_index=0, end_index=255))
             want[striplcm2noextended].append(MultiZoneMessages.GetColorZones(start_index=0, end_index=255))
             want[striplcm2extended].append(MultiZoneMessages.GetExtendedColorZones())
+            want[neon].append(MultiZoneMessages.GetExtendedColorZones())
             compare_received(want)
 
             async for serial, zones in zones_from_reference(devices.serials, sender):

--- a/tools/generate_photons_messages/adjustments.yml
+++ b/tools/generate_photons_messages/adjustments.yml
@@ -94,6 +94,10 @@ output:
           return min([req_count, res_count])
 
 
+      def extended_color_zones_response_count(res):
+          return math.ceil(res.zones_count // 82)
+
+
 types:
   duration_type:
     type: uint32
@@ -422,6 +426,11 @@ changes:
 
   MultiZoneExtendedGetColorZones:
     rename: GetExtendedColorZones
+    multi: |
+      MultiOptions(
+           lambda req: [MultiZoneMessages.StateExtendedColorZones]
+         , lambda req, res: extended_color_zones_response_count(res)
+         )
 
   MultiZoneExtendedSetColorZones:
     rename: SetExtendedColorZones


### PR DESCRIPTION
Fix for https://github.com/delfick/photons/discussions/139

Prior to this photons was not aware of multizone devices with more than 82 zones. This change makes it so that photons can wait for multiple state messages from such devices when using extended multiezone messages.